### PR TITLE
Calling createInContext: fails if the entity name is different the NSManagedObject class name

### DIFF
--- a/NSManagedObject+ActiveRecord.h
+++ b/NSManagedObject+ActiveRecord.h
@@ -16,6 +16,9 @@
 + (NSUInteger) defaultBatchSize;
 + (void) setDefaultBatchSize:(NSUInteger)newBatchSize;
 
++ (NSString *)defaultClassPrefix;
++ (void)setDefaultClassPrefix:(NSString *)newDefaultClassPrefix;
+
 + (NSArray *) executeFetchRequest:(NSFetchRequest *)request;
 + (NSArray *) executeFetchRequest:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
 + (NSFetchRequest *)createFetchRequest;

--- a/NSManagedObject+ActiveRecord.m
+++ b/NSManagedObject+ActiveRecord.m
@@ -9,6 +9,7 @@
 
 
 static NSUInteger defaultBatchSize = kActiveRecordDefaultBatchSize;
+static NSString* defaultClassPrefix = nil;
 
 @implementation NSManagedObject (ActiveRecord)
 
@@ -24,6 +25,20 @@ static NSUInteger defaultBatchSize = kActiveRecordDefaultBatchSize;
 + (NSUInteger) defaultBatchSize
 {
 	return defaultBatchSize;
+}
+
++ (NSString *)defaultClassPrefix
+{
+    return defaultClassPrefix;
+}
+
++ (void)setDefaultClassPrefix:(NSString *)newDefaultClassPrefix
+{
+    @synchronized(self)
+	{
+        [defaultClassPrefix release];
+        defaultClassPrefix = [newDefaultClassPrefix retain];
+	}
 }
 
 + (void) handleErrors:(NSError *)error
@@ -87,7 +102,15 @@ static NSUInteger defaultBatchSize = kActiveRecordDefaultBatchSize;
     else
     {
         NSString *entityName = NSStringFromClass([self class]);
-        return [NSEntityDescription entityForName:entityName inManagedObjectContext:context];
+        
+        NSString* classPrefixToStrip = [self defaultClassPrefix];
+        if (classPrefixToStrip && [entityName hasPrefix:classPrefixToStrip])
+        {
+            entityName = [entityName substringFromIndex:[classPrefixToStrip length]];
+        }
+        
+        return [NSEntityDescription entityForName:entityName
+                           inManagedObjectContext:context];
     }
 }
 


### PR DESCRIPTION
Use +entityDescription (which calls through to +entityInManagedObjectContext:) to cover the case where the entity name is different to the class name.
