### PR TITLE
This is just a simple fix to prevent unintentional releases of the default MOC.

### DIFF
--- a/NSManagedObjectContext+ActiveRecord.m
+++ b/NSManagedObjectContext+ActiveRecord.m
@@ -30,8 +30,10 @@ static NSString const * kActiveRecordManagedObjectContextKey = @"ActiveRecord_NS
 
 + (void) setDefaultContext:(NSManagedObjectContext *)moc
 {
-	[defaultManageObjectContext release];
-	defaultManageObjectContext = [moc retain];
+	if (defaultManageObjectContext != moc) {
+		[defaultManageObjectContext release];
+		defaultManageObjectContext = [moc retain];
+	}
 }
 
 + (void) resetDefaultContext


### PR DESCRIPTION
This could occur when setting the default context to the same object
multiple times.  This is just good Objective-C setter practice.
