### PR TITLE
Changed ARLog macro to not throw warning when compiling on x86 64 bit machines

### DIFF
--- a/CoreData+ActiveRecordFetching.h
+++ b/CoreData+ActiveRecordFetching.h
@@ -7,7 +7,7 @@
 #define ENABLE_ACTIVE_RECORD_LOGGING
 
 #ifdef ENABLE_ACTIVE_RECORD_LOGGING
-    #if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE || __i386__
         #define ARLog(...) NSLog(@"%s(%x) %@", __PRETTY_FUNCTION__, (unsigned int)self, [NSString stringWithFormat:__VA_ARGS__])        
     #else
         #define ARLog(...) NSLog(@"%s(%qx) %@", __PRETTY_FUNCTION__, (unsigned long long)self, [NSString stringWithFormat:__VA_ARGS__])


### PR DESCRIPTION
This is a small thing but I was getting a compiler warning from the ARLog macro when compiling on a 64 bit machine.  The proposed change makes the warning go away and I think the log method should still function in the same way.

This is the warning that was being thrown:  "warning: cast from pointer to integer of different size"

Thanks for a great library!
