### PR TITLE
Future compatibility fix for ARC.

### DIFF
--- a/CoreData+ActiveRecordFetching.h
+++ b/CoreData+ActiveRecordFetching.h
@@ -7,7 +7,7 @@
 #define ENABLE_ACTIVE_RECORD_LOGGING
 
 #ifdef ENABLE_ACTIVE_RECORD_LOGGING
-    #define ARLog(...) NSLog(@"%s(%x) %@", __PRETTY_FUNCTION__, (unsigned int)self, [NSString stringWithFormat:__VA_ARGS__])
+    #define ARLog(...) NSLog(@"%s(%p) %@", __PRETTY_FUNCTION__, self, [NSString stringWithFormat:__VA_ARGS__])
 #else
     #define ARLog(...) ((void)0)
 #endif


### PR DESCRIPTION
Since 4.2, Xcode supports Automatic Reference Counting. With ARC
enabled, casting pointers to unsigned int is prohibited.
