### PR TITLE
Added an early return in -[NSManagedObjectModel+ActiveRecord setDefaultMa

### DIFF
--- a/NSManagedObjectModel+ActiveRecord.m
+++ b/NSManagedObjectModel+ActiveRecord.m
@@ -24,6 +24,7 @@ static NSManagedObjectModel *defaultManagedObjectModel = nil;
 
 + (void) setDefaultManagedObjectModel:(NSManagedObjectModel *)newDefaultModel
 {
+	if (defaultManagedObjectModel == newDefaultModel) return;
 	[defaultManagedObjectModel release];
 	defaultManagedObjectModel = [newDefaultModel retain];
 }


### PR DESCRIPTION
Added an early return in -[NSManagedObjectModel+ActiveRecord setDefaultManagedObjectModel:].
If the passed model was the same as the current one, it could have been dealloced in between.
(Ref count -1, +1 can pass by 0.)
