### PR TITLE
Add -setErrorHandlerTarget:action: method.

### DIFF
--- a/ActiveRecordHelpers.h
+++ b/ActiveRecordHelpers.h
@@ -23,6 +23,7 @@ typedef void (^CoreDataBlock)(NSManagedObjectContext *context);
 
 + (void) handleErrors:(NSError *)error;
 - (void) handleErrors:(NSError *)error;
++ (void) setErrorHandlerTarget:(id)target action:(SEL)action;
 
 + (void) setupCoreDataStack;
 + (void) setupCoreDataStackWithInMemoryStore;


### PR DESCRIPTION
Please see the commit message for implementation/usage details.

I've tried implementing a block-based error handling mechanism first, but it was causing awful troubles, since you'd have to retain the block, which in turn auto-retains any used variables. Because users are probably going to reference "self" in these blocks, this would cause implicit retain cycles (and thus memory leaks). The user should a.) be aware of this and b.) prevent from it in their block's implementation themselves.

In general, I figured this behaviour would be inconspicuous and dangerous, and settled for the non-retaining classical target-action mechanism.
