### PR TITLE
Fixed conditionals for Mac and iOS

### DIFF
--- a/NSPersistentStore+ActiveRecord.m
+++ b/NSPersistentStore+ActiveRecord.m
@@ -35,7 +35,7 @@ static NSPersistentStore *defaultPersistentStore = nil;
 + (NSString *)applicationLibraryDirectory
 {
 
-#ifdef TARGET_OS_MAC
+#ifndef TARGET_OS_IPHONE
         
     NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
     return [[self directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];


### PR DESCRIPTION
- removed #ifdef TARGET_OS_MAC and added #ifndef TARGET_OS_IPHONE.
  Conditionals behavior are available here: http://sealiesoftware.com/blog/archive/2010/8/16/TargetConditionalsh.html

Signed-off-by: Luca Liberati liberatiluca@me.com
