### PR TITLE
New core data store fails to be created on iPhone

### DIFF
--- a/NSPersistentStore+ActiveRecord.m
+++ b/NSPersistentStore+ActiveRecord.m
@@ -35,14 +35,14 @@ static NSPersistentStore *defaultPersistentStore = nil;
 + (NSString *)applicationLibraryDirectory
 {
 
-#ifdef TARGET_OS_MAC
+#ifdef TARGET_OS_IPHONE
         
-    NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
-    return [[self directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];
+  return [self directory:NSLibraryDirectory];
         
-#elif defined(TARGET_OS_IPHONE)
+#elif TARGET_OS_MAC
 
-    return [self directory:NSLibraryDirectory];
+  NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
+  return [[self directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];
         
 #else
 #warning Unsupported OS Target specified


### PR DESCRIPTION
Exceptions are raised when trying to create a new core data sqlite store on the iPhone. This is because the wrong path gets generated for the sqlite database. The #if and #elif directives test the OS in the wrong order. TARGET_OS_MAC exists on the iPhone, so a mac-compatible sqlite directory path is used rather than the iPhone one. I've fixed this up and will create a pull request for you.
