### PR TITLE
Missing prefixes in cleanUp

### DIFF
--- a/Source/MagicalRecordHelpers.m
+++ b/Source/MagicalRecordHelpers.m
@@ -16,9 +16,9 @@ static SEL errorHandlerAction = nil;
 {
 	[MRCoreDataAction cleanUp];
 	[NSManagedObjectContext setDefaultContext:nil];
-	[NSManagedObjectModel setDefaultManagedObjectModel:nil];
+	[NSManagedObjectModel MR_setDefaultManagedObjectModel:nil];
 	[NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:nil];
-	[NSPersistentStore setDefaultPersistentStore:nil];
+	[NSPersistentStore MR_setDefaultPersistentStore:nil];
 }
 
 + (void) defaultErrorHandler:(NSError *)error


### PR DESCRIPTION
Sample app with prefixes turned on wasn't working cause cleanUp was missing them. Should be fixed now.
