### PR TITLE
Fix compiler warning about unused variable in release builds.

### DIFF
--- a/Source/Categories/NSManagedObject+MagicalDataImport.m
+++ b/Source/Categories/NSManagedObject+MagicalDataImport.m
@@ -83,8 +83,7 @@ NSString * const kMagicalRecordImportRelationshipTypeKey = @"type";
         return nil;
     }
     
-    Class managedObjectClass = NSClassFromString([destinationEntity managedObjectClassName]);
-    NSAssert([managedObjectClass isSubclassOfClass:[NSManagedObject class]], @"Entity is not a managed object! Whoa!");
+    NSAssert([NSClassFromString([destinationEntity managedObjectClassName]) isSubclassOfClass:[NSManagedObject class]], @"Entity is not a managed object! Whoa!");
     
 //    NSString *lookupKey = [[destinationEntity userInfo] valueForKey:kNSManagedObjectAttributeJSONKeyMapKey] ?: [destinationEntity name];
     


### PR DESCRIPTION
With all the commented-out code, and NSAssert getting compiled out by default in non-Debug builds, this throws a compiler warning.
