### PR TITLE
Fixed a semantic issue with an NSManagedObjectContext category and fixed a potential NSManagedObjectContext memory leak.

### DIFF
--- a/Magical Record.xcodeproj/project.xcworkspace/xcuserdata/jessebunch.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/Magical Record.xcodeproj/project.xcworkspace/xcuserdata/jessebunch.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceUserSettings_HasAskedToTakeAutomaticSnapshotBeforeSignificantChanges</key>
+	<true/>
+	<key>IDEWorkspaceUserSettings_SnapshotAutomaticallyBeforeSignificantChanges</key>
+	<true/>
+</dict>
+</plist>

--- a/Magical Record.xcodeproj/xcuserdata/jessebunch.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Magical Record.xcodeproj/xcuserdata/jessebunch.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>C721C7DB13D0C3A00097AB6F</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>C721C7FC13D0C3CD0097AB6F</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Source/Categories/NSManagedObjectContext+MagicalRecord.h
+++ b/Source/Categories/NSManagedObjectContext+MagicalRecord.h
@@ -28,7 +28,7 @@
 + (void) setDefaultContext:(NSManagedObjectContext *)moc;
 + (void) resetContextForCurrentThread;
 
-+ (NSManagedObjectContext *) context;
++ (NSManagedObjectContext *) newContext;
 + (NSManagedObjectContext *) contextForCurrentThread;
 
 + (NSManagedObjectContext *) contextThatNotifiesDefaultContextOnMainThread;

--- a/Source/Categories/NSManagedObjectContext+MagicalRecord.m
+++ b/Source/Categories/NSManagedObjectContext+MagicalRecord.m
@@ -215,14 +215,14 @@ static NSString const * kMagicalRecordManagedObjectContextKey = @"MagicalRecord_
     return context;
 }
 
-+ (NSManagedObjectContext *) context
++ (NSManagedObjectContext *) newContext
 {
 	return [self contextWithStoreCoordinator:[NSPersistentStoreCoordinator MR_defaultStoreCoordinator]];
 }
 
 + (NSManagedObjectContext *) contextThatNotifiesDefaultContextOnMainThread
 {
-    NSManagedObjectContext *context = [self context];
+    NSManagedObjectContext *context = [self newContext];
     context.notifiesMainContextOnSave = YES;
     return context;
 }

--- a/Source/MagicalRecordHelpers.m
+++ b/Source/MagicalRecordHelpers.m
@@ -115,8 +115,9 @@ static BOOL shouldAutoCreateDefaultPersistentStoreCoordinator_;
 
 + (void) setupCoreDataStack
 {
-    NSManagedObjectContext *context = [NSManagedObjectContext context];
+    NSManagedObjectContext *context = [NSManagedObjectContext newContext];
 	[NSManagedObjectContext setDefaultContext:context];
+	[context release];
 }
 
 + (void) setupAutoMigratingCoreDataStack


### PR DESCRIPTION
Because `[NSManagedObjectContext context]` alloc and inits a new context, it should be renamed to  newContext so that the analyzer is alerted that a new instance is created. Also, there was a memory leak in the
`[MagicalRecordHelpers setupCoreDataStack]` method since the `[NSManagedObjectContext setDefaultContext:]` method retains the newly created context.
