### PR TITLE
Referenced non-public APIs which caused AppStore rejection.

### DIFF
--- a/Source/Categories/NSManagedObject+MagicalRecord.m
+++ b/Source/Categories/NSManagedObject+MagicalRecord.m
@@ -70,16 +70,17 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 
 + (NSEntityDescription *)entityDescriptionInContext:(NSManagedObjectContext *)context
 {
-    if ([self respondsToSelector:@selector(entityInManagedObjectContext:)]) 
-    {
-        NSEntityDescription *entity = [self performSelector:@selector(entityInManagedObjectContext:) withObject:context];
-        return entity;
-    }
-    else
-    {
+	// APPSTORE REJECTED : Referenced non-public API
+    // if ([self respondsToSelector:@selector(entityInManagedObjectContext:)]) 
+    // {
+    //     NSEntityDescription *entity = [self performSelector:@selector(entityInManagedObjectContext:) withObject:context];
+    //     return entity;
+    // }
+    // else
+    // {
         NSString *entityName = NSStringFromClass([self class]);
         return [NSEntityDescription entityForName:entityName inManagedObjectContext:context];
-    }
+    // }
 }
 
 + (NSEntityDescription *)entityDescription
@@ -586,16 +587,17 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 
 + (id) createInContext:(NSManagedObjectContext *)context
 {
-    if ([self respondsToSelector:@selector(insertInManagedObjectContext:)]) 
-    {
-        id entity = [self performSelector:@selector(insertInManagedObjectContext:) withObject:context];
-        return entity;
-    }
-    else
-    {
+	// APPSTORE REJECTED : Referenced non-public API
+    // if ([self respondsToSelector:@selector(insertInManagedObjectContext:)]) 
+    // {
+    //     id entity = [self performSelector:@selector(insertInManagedObjectContext:) withObject:context];
+    //     return entity;
+    // }
+    // else
+    // {
         NSString *entityName = NSStringFromClass([self class]);
         return [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context];
-    }
+    // }
 }
 
 + (id)createEntity


### PR DESCRIPTION
First of all, great work on MagicalRecord. Coming from a ruby background, it made CoreData a whole lot easier.

I had issues submitting my application this weekend and Apple's ApplicationLoader (the new one which scans private APIs) flagged the methods in this commit as issues (which caused rejection of binary). The error from Apple was:

`The app references non-public selectors in PocketSalsa.app/ PocketSalsa: entityInManagedObjectContext:, insertInManagedObjectContext`.

After editing my fork and making sure my edits worked, I resubmitted it and the binary it was finally accepted. There is probably a better fix for this, but I'm not an expert on MagicalRecord as you are.

Thanks.
