### PR TITLE
Add support for NSManagedObject subclass names that are not the same as the CoreData entity name

### DIFF
--- a/Source/Categories/NSManagedObject+MagicalRecord.m
+++ b/Source/Categories/NSManagedObject+MagicalRecord.m
@@ -11,6 +11,12 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 @implementation NSManagedObject (MagicalRecord)
 
 
++ (NSString *)entityName {
+    
+    return NSStringFromClass([self class]);
+}
+
+
 + (void) setDefaultBatchSize:(NSUInteger)newBatchSize
 {
 	@synchronized(self)
@@ -77,7 +83,7 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     }
     else
     {
-        NSString *entityName = NSStringFromClass([self class]);
+        NSString *entityName = [self entityName];
         return [NSEntityDescription entityForName:entityName inManagedObjectContext:context];
     }
 }
@@ -593,12 +599,7 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     }
     else
     {
-        NSString *entityName = nil;
-        
-        if ([self respondsToSelector:@selector(entityName)])
-            entityName = [self performSelector:@selector(entityName)];
-        else
-            entityName = NSStringFromClass([self class]);
+        NSString *entityName = [self entityName];
         
         return [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:context];
     }


### PR DESCRIPTION
Magical record uses `NSStringFromClass([self class])` to get the entity name for inserting/updating/deleting, but CoreData allows you to define a name for the `NSManagedObject` subclass that is not the same as the CoreData entity name.

For example, in my typical workflow I would have an entity named `SomeEntity`, but I would name the `NSManagedObject` subclass `FSManagedSomeEntity`. Don't ask me why I do this, I'm just very picky.

So anyway, these commits define a class method in the `NSManagedObject+MagicalRecord` category `[NSManagedObject entityName]` who's implementation calls `NSStringFromClass([self class])` and is called from all the places where `NSStringFromClass([self class])` was previously being used. This allows the subclasses of `NSManagedObject` to override this method and return the correct entity name. To continue my previous example, my `FSManagedSomeEntity` class would override `[NSManagedObject entityName]` like so:

``` obj-c

@interface FSManagedSomeEntity : NSManagedObject
@end


@implementation FSManagedSomeEntity

+ (NSString *)entityName {

    return @"SomeEntity";
}

@end
```
