### PR TITLE
Add CocoaPods pod spec.

### DIFF
--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name     = 'MagicalRecord'
+  s.version  = '1.7.1'
+  s.license  = 'MIT'
+  s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1! '
+  s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
+  s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
+  s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.7.1' }
+  s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
+  s.source_files = 'Source/**/*.{h,m}'
+  s.framework    = 'CoreData'
+
+  def s.post_install(target)
+    prefix_header = config.project_pods_root + target.prefix_header_filename
+    prefix_header.open('a') do |file|
+      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND 1\n#import "CoreData+MagicalRecord.h"\n#endif})
+    end
+  end
+end


### PR DESCRIPTION
I’ve added this spec for 1.7.1 to the specs repo: https://github.com/CocoaPods/Specs/blob/master/MagicalRecord/1.7.1/MagicalRecord.podspec

If you add this spec to the root of your repo, you will be able to easily keep it in sync with source changes and users will be able to install the bleeding-edge directly from your repo.

Finally, you can now push to the spec repo, so that you can add a spec for a future version.

Thanks for your time, Saul! :)
