### PR TITLE
Variable typo

### DIFF
--- a/Source/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/Source/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -135,10 +135,10 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
 	NSManagedObjectModel *model = [NSManagedObjectModel MR_defaultManagedObjectModel];
 	NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
 
-    [psc MR_addInMemoryStore];
+    [coordinator MR_addInMemoryStore];
     MR_AUTORELEASE(coordinator);
 
-    return psc;
+    return coordinator;
 }
 
 + (NSPersistentStoreCoordinator *) MR_newPersistentStoreCoordinator


### PR DESCRIPTION
Since coordinator is used in the rest of the file (instead of psc), I went for coordinator
