### PR TITLE
Fix clang warning in NSManagedObjectContext category

### DIFF
--- a/Source/Categories/NSManagedObjectContext+MagicalRecord.m
+++ b/Source/Categories/NSManagedObjectContext+MagicalRecord.m
@@ -238,15 +238,16 @@ static void const * kMagicalRecordNotifiesMainContextAssociatedValueKey = @"kMag
     NSManagedObjectContext *mainContext = [[self class] MR_defaultContext];
     if (self != mainContext) 
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         THREAD_ISOLATION_ENABLED(
         SEL selector = enabled ? @selector(MR_observeContextOnMainThread:) : @selector(MR_stopObservingContext:);
         objc_setAssociatedObject(self, kMagicalRecordNotifiesMainContextAssociatedValueKey, [NSNumber numberWithBool:enabled], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"        
+
         [mainContext performSelector:selector withObject:self];
-#pragma clang diagnostic pop
                                  )
+#pragma clang diagnostic pop
+
         PRIVATE_QUEUES_ENABLED(
                                if (enabled)
                                {


### PR DESCRIPTION
Clang seems to need the diagnostic pragma to cover the
`THREAD_ISOLATION_ENABLED()` macro as well as the `performSelector:`
method to suppress this warning.
