### PR TITLE
Deadlock during the NSManagedObjectContext's executeFetchRequest

### DIFF
--- a/Source/Categories/NSManagedObject+MagicalRecord.m
+++ b/Source/Categories/NSManagedObject+MagicalRecord.m
@@ -26,8 +26,18 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 + (NSArray *) MR_executeFetchRequest:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context
 {
 	NSError *error = nil;
+    
+    PRIVATE_QUEUES_ENABLED
+    (
+        [[context persistentStoreCoordinator] lock];
+    )
 	
 	NSArray *results = [context executeFetchRequest:request error:&error];
+    
+    PRIVATE_QUEUES_ENABLED
+    (
+        [[context persistentStoreCoordinator] unlock];
+    )
     
     if (results == nil) 
     {


### PR DESCRIPTION
Before the thread isolation mode was added we were experiencing deadlocks when run in iOS 5.  Locking and unlocking the NSPersistentStore before and after the executeFetchRequest seems to have solved it.

Not sure how valid this is anymore that thread isolation is added.  I'm experiencing the same problem as issue #111 when run in thread isolation mode so for now we must run in private queue mode on iOS 5 with this locking scheme.
