### PR TITLE
Use user specified ruby installation path instead of defaulting to homebrew installation.

### DIFF
--- a/generateShorthandFile.rb
+++ b/generateShorthandFile.rb
@@ -1,4 +1,4 @@
-#!/usr/local/Cellar/ruby/1.9.2-p290/bin/ruby
+#!/usr/bin/env ruby
 #
 #  ProcessHeader.rb
 #  Magical Record


### PR DESCRIPTION
Not everyone has their ruby installed by Homebrew, or that specific version. The `env` utility invokes the ruby that is first in the users PATH. This will allow people who don't have ruby installed by homebrew to build MR.
