### PR TITLE
Prefix category methods

### DIFF
--- a/Source/CoreData+MagicalRecord.h
+++ b/Source/CoreData+MagicalRecord.h
@@ -32,14 +32,24 @@
 #define kCFCoreFoundationVersionNumber_iPhoneOS_5_0 674.0
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_10_7
+#define kCFCoreFoundationVersionNumber_10_7 635.0
+#endif
+
+#if TARGET_OS_IPHONE == 0
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_10_7
+#else
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_iPhoneOS_5_0
+#endif
+
 #define PRIVATE_QUEUES_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber >= MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }
 
 #define THREAD_ISOLATION_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber < MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }


### PR DESCRIPTION
This all looks like really neat and useful stuff.  However, categories on classes that you do not own (NSManagedObjectContext, etc.), should really, really be prefixed to avoid conflicts. This avoids conflicts not only with other helper categories, but avoids conflicting with Apple's private methods.
