### PR TITLE
iCloud data sync and NSManagedObjectContext

### DIFF
--- a/Source/CoreData+MagicalRecord.h
+++ b/Source/CoreData+MagicalRecord.h
@@ -32,14 +32,24 @@
 #define kCFCoreFoundationVersionNumber_iPhoneOS_5_0 674.0
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_10_7
+#define kCFCoreFoundationVersionNumber_10_7 635.0
+#endif
+
+#if TARGET_OS_IPHONE == 0
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_10_7
+#else
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_iPhoneOS_5_0
+#endif
+
 #define PRIVATE_QUEUES_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber >= MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }
 
 #define THREAD_ISOLATION_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber < MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }


### PR DESCRIPTION
Hi,

I've recently been experimenting with the iCloud core data support in MagicalRecord and think I may have found an issue. When syncing data from iCloud back to a core data store on OSX application using MagicalRecord, an error message is popped:

> 2011-12-29 09:40:44.296 iCloudDataMac[35912:523f] CoreData: Ubiquity: Error importing transaction log: <PFUbiquityTransactionLog: 0x10056c7f0>
>     transactionLogLocation: <PFUbiquityLocation: 0x10014b670>: /Users/rickerbh/Library/Mobile Documents/XXXXXXX~com~glimmerdesign~test~iCloudDataMac/TransactionLogs/mobile.XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX/iCloudData.store/B8QDvwieWRaMLOCloeJolPkbz3jl080sbPBNlbJsM~U=/C38F55E9-83D4-4728-A822-3BD0FFC2D212.1.cdt
>     transactionNumber: 1
> , exception: Can only use -performBlock: on an NSManagedObjectContext that was created with a queue.

It seems that some of the callbacks/notifications don't get triggered when this error arises, although the core data store is correctly updated.

The PRIVATE_QUEUES_ENABLED macro defined in CoreData+MagicalRecord.h only applies to devices that are iOS5 or higher, so the THREAD_ISOLATION_ENABLED macro is what is applied on Mac apps, from what I can see.

I see there are two solutions to this.
1. Update the macro so PRIVATE_QUEUES_ENABLED works for >=iOS5 devices or Mac apps on >=OSX10.7, or
2. Update the functions to not use the performBlock facilities, and trigger the notifications another way.

I've updated the macros in my code - although I'm not sure what the side effects (if any) are of using the private queue mechanism on OSX.

I'm happy to create a pull request for my updated macro - just let me know if this is the way you'd like to proceed. If it's user error I'd love to understand what the mistake is.

Cheers,

H.
