### PR TITLE
Modified macro to avoid "Can only use -performBlock" error

### DIFF
--- a/Source/CoreData+MagicalRecord.h
+++ b/Source/CoreData+MagicalRecord.h
@@ -32,17 +32,28 @@
 #define kCFCoreFoundationVersionNumber_iPhoneOS_5_0 674.0
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_10_7
+#define kCFCoreFoundationVersionNumber_10_7 635.0
+#endif
+
+#if TARGET_OS_IPHONE == 0
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_10_7
+#else
+#define MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION kCFCoreFoundationVersionNumber_iPhoneOS_5_0
+#endif
+
 #define PRIVATE_QUEUES_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber >= MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }
 
 #define THREAD_ISOLATION_ENABLED(...) \
-    if (kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_iPhoneOS_5_0) \
+    if (kCFCoreFoundationVersionNumber < MR_MINIMUM_PRIVATE_QUEUE_CF_VERSION) \
     { \
         __VA_ARGS__ \
     }
+
 
 #if MR_USE_ARC
 #define MR_RETAIN(xx)


### PR DESCRIPTION
Here's a fix on a clean branch. 
