### PR TITLE
EXC_BAD_ACCESS when property is not found

### DIFF
--- a/Source/Categories/NSManagedObject+MagicalRecord.m
+++ b/Source/Categories/NSManagedObject+MagicalRecord.m
@@ -113,7 +113,7 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 			}
 			else
 			{
-				MRLog(@"Property '%@' not found in %@ properties for %@", propertyName, [propDict count], NSStringFromClass(self));
+				MRLog(@"Property '%@' not found in %d properties for %@", propertyName, [propDict count], NSStringFromClass(self));
 			}
 		}
 	}


### PR DESCRIPTION
## How to reproduce

Call method that is using `propertiesNamed`, for example `findFirstWithAttribute:withValue:` with nonexistent property. The reporting log message will cause EXC_BAD_ACCESS for trying to print out an integer using `%@` which expects a pointer to an object.

Also, logging must be enabled.
### Environment

Mac OS X 10.7
## Notes

I used a subset of MagicalRecord that was copied over to RestKit. I looked at the source code for MagicalRecord and it seems to have the same issue. There's a slight chance it's a non-issue when using whole MagicalRecord library, but I don't think it is.
