### PR TITLE
Clarified that you must first define MR_SHORTHAND and then import the header file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Magical Record for Core Data was inspired by the ease of Ruby on Rails' Active R
 
 1. In your XCode Project, add all the .h and .m files from the *Source* folder into your project. 
 2. Add *CoreData+MagicalRecord.h* file to your PCH file or your AppDelegate file.
-    * Optionally add `#define MR_SHORTHAND` to your PCH file if you want to use shorthand like `findAll` instead of `MR_findAll`
+    * Optionally add `#define MR_SHORTHAND` to your PCH file before you import CoreData+MagicalRecord.h if you want to use shorthand like `findAll` instead of `MR_findAll`
 4. Start writing code! ... There is no step 3!
 
 # ARC Support


### PR DESCRIPTION
I just spend way to much time figuring out why I got ARC errors complaining about MagicalRecord methods that not existed. Turned out I first imported the header file of MagicalRecord and on the next line defined the MR_SHORTHAND macro.

I think it should be nice to state somewhat more clearly that you must first define the shorthand macro.
