### PR TITLE
The parent context needs to get saved in its own thread.

### DIFF
--- a/Source/Categories/NSManagedObjectContext+MagicalRecord.m
+++ b/Source/Categories/NSManagedObjectContext+MagicalRecord.m
@@ -174,7 +174,9 @@ static void const * kMagicalRecordNotifiesMainContextAssociatedValueKey = @"kMag
     {
         if (saved && [self respondsToSelector:@selector(parentContext)] && [self performSelector:@selector(parentContext)])
         {
-            [[self parentContext] MR_saveWithErrorHandler:errorCallback];
+            [[self parentContext] performBlockAndWait:^{
+                [[self parentContext] MR_saveWithErrorHandler:errorCallback];
+            }];
         }
         if (!saved)
         {


### PR DESCRIPTION
Every context should perform its save operation on the correct thread, this is especially important for the defaultContext.
