### PR TITLE
Updated MR_requestAllSortedBy methods to handle '+'/'-' flags embedded in the comma-separated sortTerm string for attribute-specific ascending/descending

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -94,17 +94,26 @@
 {
 	NSFetchRequest *request = [self MR_requestAllInContext:context];
 	
-	NSSortDescriptor *sortBy = [[NSSortDescriptor alloc] initWithKey:sortTerm ascending:ascending];
-	[request setSortDescriptors:[NSArray arrayWithObject:sortBy]];
-	
+    NSMutableArray* sortDescriptors = [[NSMutableArray alloc] init];
+    NSArray* sortKeys = [sortTerm componentsSeparatedByString:@","];
+    for (NSString* sortKey in sortKeys) 
+    {
+        NSString* firstCharacter = [NSString stringWithFormat:@"%c", [sortKey characterAtIndex:0]];
+        BOOL ascendingForSortTerm = !([firstCharacter isEqualToString:@"-"]);
+        ascendingForSortTerm *= ascending; // Boolean algebra to give the method-level 'ascending' argument proper influence         
+        NSString* trimmedSortKey = [sortKey stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"+-"]]; // Assumes there are no desired '+'/'-' characters in sortKey as those are invalid in Core Data anyhow
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:trimmedSortKey ascending:ascendingForSortTerm];
+        [sortDescriptors addObject:sortDescriptor];
+    }
+	[request setSortDescriptors:sortDescriptors];
 	return request;
 }
 
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending
 {
 	return [self MR_requestAllSortedBy:sortTerm
-                             ascending:ascending
-                             inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+						  ascending:ascending
+						  inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
@@ -117,12 +126,14 @@
     NSArray* sortKeys = [sortTerm componentsSeparatedByString:@","];
     for (NSString* sortKey in sortKeys) 
     {
-        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        NSString* firstCharacter = [NSString stringWithFormat:@"%c", [sortKey characterAtIndex:0]];
+        BOOL ascendingForSortTerm = !([firstCharacter isEqualToString:@"-"]);
+        ascendingForSortTerm *= ascending; // Boolean algebra to give the method-level 'ascending' argument proper influence
+        NSString* trimmedSortKey = [sortKey stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"+-"]]; // Assumes there are no desired '+'/'-' characters in sortKey as those are invalid in Core Data anyhow
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:trimmedSortKey ascending:ascendingForSortTerm];
         [sortDescriptors addObject:sortDescriptor];
     }
-    
 	[request setSortDescriptors:sortDescriptors];
-    
 	return request;
 }
 


### PR DESCRIPTION
...n the comma-separated sortTerm string for attribute-specific ascending/descending

The sortTerm string (which could already accept a comma-separated list of attributes) can now parse '+' and '-' characters (optionally) prepended to each attribute so that the sort can be ascending by some attributes and descending by others.

Notes:
- The method-level 'ascending' BOOL argument still has effect as the master, making the '+'/'-' flags relative to the master sort order
- The '+' is strictly optional as ascending is the default if no flag is used
- All legacy behavior of these methods is preserved

EXAMPLE:
    sortTerm: @"-golfScore,lastName,+firstName"
would return results sorted first by descending golfScore, then ascending lastName, then ascending firstName

If the method-level 'ascending' BOOL were passed as NO then the sort order would be ascending by golfScore, then descending by lastName, then descending by firstName

Signed-off-by: Joel Lenorovitz joel@mobileXware.com
