### PR TITLE
Call completion handler on main thread.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -98,7 +98,7 @@
     
         if (completion) 
         {
-            completion();
+            dispatch_async(dispatch_get_main_queue(), completion);
         }
     }];
 }


### PR DESCRIPTION
The completion handler in `MR_saveInBackgroundErrorHandler:completion:` should be called on the main thread, and this does exactly that.
