### PR TITLE
Cache the predicate, making it into a method so it can be accessed...

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -8,6 +8,8 @@
 
 #import <CoreData/CoreData.h>
 
+
+
 @interface NSManagedObject (MagicalFinders)
 
 + (NSArray *) MR_findAll;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -11,10 +11,11 @@
 #import "NSManagedObject+MagicalRecord.h"
 #import "NSManagedObjectContext+MagicalThreading.h"
 
+
 @implementation NSManagedObject (MagicalFinders)
 
-#pragma mark - Finding Data
 
+#pragma mark - Finding Data
 
 + (NSArray *) MR_findAllInContext:(NSManagedObjectContext *)context
 {
@@ -180,7 +181,12 @@
 
 + (NSArray *) MR_findByAttribute:(NSString *)attribute withValue:(id)searchValue andOrderBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context
 {
-	NSPredicate *searchTerm = [NSPredicate predicateWithFormat:@"%K = %@", attribute, searchValue];
+  
+  NSDictionary *searchTerms = [NSDictionary 
+                               dictionaryWithObjectsAndKeys:searchValue, @"VALUE", attribute, @"KEY", nil];
+//  [NSPredicate predicateWithFormat:@"%K = %@", attribute, searchValue];
+	NSPredicate *searchTerm = [[self MR_findByAttributePredicate] predicateWithSubstitutionVariables:searchTerms];
+  ;
 	NSFetchRequest *request = [self MR_requestAllSortedBy:sortTerm ascending:ascending withPredicate:searchTerm inContext:context];
 	
 	return [self MR_executeFetchRequest:request];

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.h
@@ -10,6 +10,8 @@
 
 @interface NSManagedObject (MagicalRequests)
 
++(NSPredicate *) MR_findByAttributePredicate;
+
 + (NSFetchRequest *) MR_createFetchRequest;
 + (NSFetchRequest *) MR_createFetchRequestInContext:(NSManagedObjectContext *)context;
 

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -13,6 +13,22 @@
 @implementation NSManagedObject (MagicalRequests)
 
 
+#pragma mark - 
+#pragma mark Predicates
++(NSPredicate *) MR_findByAttributePredicate; {
+  static NSPredicate * findByAttributePredicate_ = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+      findByAttributePredicate_ = [NSPredicate predicateWithFormat:@"$KEY = $VALUE"];
+  });
+  
+  return findByAttributePredicate_;
+}
+
+
+#pragma mark - 
+#pragma mark Requests
+
 + (NSFetchRequest *)MR_createFetchRequestInContext:(NSManagedObjectContext *)context
 {
 	NSFetchRequest *request = [[NSFetchRequest alloc] init];
@@ -58,8 +74,12 @@
 + (NSFetchRequest *) MR_requestAllWhere:(NSString *)property isEqualTo:(id)value inContext:(NSManagedObjectContext *)context
 {
     NSFetchRequest *request = [self MR_createFetchRequestInContext:context];
-    [request setPredicate:[NSPredicate predicateWithFormat:@"%K = %@", property, value]];
-    
+
+    NSDictionary * searchTerms = [NSDictionary 
+                                  dictionaryWithObjectsAndKeys:value, @"VALUE",property, @"KEY",nil];
+  
+    [request setPredicate:[[self MR_findByAttributePredicate] 
+                           predicateWithSubstitutionVariables:searchTerms]];    
     return request;
 }
 


### PR DESCRIPTION
We (and maybe others) use the findByAttribute a lot and occasionally do it inside loops in situation we can't use an "IN ARRAY" type of queries. 
So, no need to rebuild the predicate each time, just the values. 
