### PR TITLE
Wrong selector name for ordered relationship in MR_addObject:forRelationship

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -90,7 +90,7 @@ NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  
         if ([relationshipInfo respondsToSelector:@selector(isOrdered)] && [relationshipInfo isOrdered])
         {
             //Need to get the ordered set
-            NSString *selectorName = [[relationshipInfo name] stringByAppendingString:@"Set"];
+            NSString *selectorName = [relationshipInfo name];
             relationshipSource = [self performSelector:NSSelectorFromString(selectorName)];
             addRelationMessageFormat = @"addObject:";
         }


### PR DESCRIPTION
The code assumes that the ordered relationship accessor ends with "Set", this fails with code auto-generated by Xcode and is generally a wrong assumption to make. Here's the offending line:

https://github.com/magicalpanda/MagicalRecord/blob/master/MagicalRecord/Categories/NSManagedObject/NSManagedObject%2BMagicalDataImport.m#L93
