### PR TITLE
[NSManagedObjectContext MR_saveInBackgroundErrorHandler:completion:]

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -98,7 +98,7 @@
 
 - (void) MR_saveInBackgroundErrorHandler:(void (^)(NSError *))errorCallback completion:(void (^)(void))completion;
 {
-    [self performBlock:^{
+    [self performBlockAndWait:^{
         [self MR_saveWithErrorCallback:errorCallback];
 
         if (self == [[self class] MR_defaultContext])


### PR DESCRIPTION
- Only dispatch completion handler when it's not nil.
- Wait for the block to complete.
