### PR TITLE
Child context not saving in background and completion handler not called

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -104,6 +104,8 @@
         if (self == [[self class] MR_defaultContext])
         {
             [[[self class] MR_rootSavingContext] MR_saveInBackgroundErrorHandler:errorCallback completion:completion];
+        } else if (self.parentContext != nil) {
+            [self.parentContext MR_saveInBackgroundErrorHandler:errorCallback completion:completion];
         }
 
         if (completion && self == [[self class] MR_rootSavingContext])


### PR DESCRIPTION
I was trying to call saveInBackgroundWithBlock:completion from a NSManagedContext that was not the default or the root saving context.

I found that the completion handler was never called because it was by passing both if statements so the dispatch_async was skipped over.

I'm not sure this is the right way to fix this, but it is working for my situation.
