### PR TITLE
Default value when attribute key path was not present in import dictionary

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -21,6 +21,7 @@ NSString * const kMagicalRecordImportRelationshipMapKey             = @"mappedKe
 NSString * const kMagicalRecordImportRelationshipLinkedByKey        = @"relatedByAttribute";
 NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  //this needs to be revisited
 
+NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"useDefaultValueWhenNotPresent";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
@@ -52,6 +53,17 @@ NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  
             if (![self MR_importValue:value forKey:attributeName])
             {
                 [self setValue:value forKey:attributeName];
+            }
+        } 
+        else 
+        {
+            if ([[[attributeInfo userInfo] objectForKey:kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent] boolValue]) 
+            {
+                id value = [attributeInfo defaultValue];
+                if (![self MR_importValue:value forKey:attributeName])
+                {
+                    [self setValue:value forKey:attributeName];
+                }
             }
         }
     }


### PR DESCRIPTION
Added the key for userinfo useDefaultValueWhenNotPresent, when set YES... it will put the attributeValue to a default value if it was not found in the import dictionary

this also allow to nil the attribute from server
