### PR TITLE
completion block is not called when MR_saveInBackgroundErrorHandler:completion: is called on a child of the default context 

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -100,17 +100,21 @@
 {
     [self performBlockAndWait:^{
         [self MR_saveWithErrorCallback:errorCallback];
-
+        
+        // If it's the default context, save the rootSavingContext too, THEN call the completion handler
         if (self == [[self class] MR_defaultContext])
         {
             [[[self class] MR_rootSavingContext] MR_saveInBackgroundErrorHandler:errorCallback completion:completion];
-        }
-
-        if (completion && self == [[self class] MR_rootSavingContext])
-        {
-            dispatch_async(dispatch_get_main_queue(), completion);
+        } else {
+            // If it's a child context, or if we've hit the root context, call the completion block.
+            // Basically, the ONLY time we don't call it's called on the default context, and there is an implied root save
+            if (completion)
+            {
+                dispatch_async(dispatch_get_main_queue(), completion);
+            }
         }
     }];
+
 }
 
 @end


### PR DESCRIPTION
It's currently only going to be called if it's saving the root context. calling it on the default queue causes it to save the root queue (and hence trigger the callback). If you use a child of the default context, it does not get called.
As a result saveInBackgroundWithBlock:completion:errorHandler: (in actions) never fires it's callback because it uses a child context, which is neither the default nor root context.

(hope that was understandable)
