### PR TITLE
Make all requestAllSortedBy* methods consistent (allows sortTerms with commas)

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -92,12 +92,10 @@
 
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context
 {
-	NSFetchRequest *request = [self MR_requestAllInContext:context];
-	
-	NSSortDescriptor *sortBy = [[NSSortDescriptor alloc] initWithKey:sortTerm ascending:ascending];
-	[request setSortDescriptors:[NSArray arrayWithObject:sortBy]];
-	
-	return request;
+	return [self MR_requestAllSortedBy:sortTerm
+                             ascending:ascending
+                         withPredicate:nil 
+                             inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending
@@ -110,7 +108,7 @@
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
 {
 	NSFetchRequest *request = [self MR_requestAllInContext:context];
-	[request setPredicate:searchTerm];
+	if (searchTerm) [request setPredicate:searchTerm];
 	[request setFetchBatchSize:[self MR_defaultBatchSize]];
 	
     NSMutableArray* sortDescriptors = [[NSMutableArray alloc] init];


### PR DESCRIPTION
Small change to allow all requests to use comma separated sort terms, example:
`entities = [SomeEntity findAllSortedBy:@"order,name" ascending:YES]`
