### PR TITLE
Fix for MR_inContext not working on temporary ids

### DIFF
--- a/Project Files/Unit Tests/NSManagedObjectContextHelperTests.m
+++ b/Project Files/Unit Tests/NSManagedObjectContextHelperTests.m
@@ -7,8 +7,14 @@
 //
 
 #import "NSManagedObjectContextHelperTests.h"
+#import "SingleRelatedEntity.h"
 
 @implementation NSManagedObjectContextHelperTests
+
+- (void) setUpClass
+{
+    [NSManagedObjectModel MR_setDefaultManagedObjectModel:[NSManagedObjectModel MR_managedObjectModelNamed:@"TestModel.momd"]];
+}
 
 - (void) setUp
 {
@@ -17,10 +23,10 @@
 
 - (void) tearDown
 {
-    [MagicalRecord cleanUp];
+    //[MagicalRecord cleanUp];
 }
 
-- (void) testCanCreateContextForCurrentThead
+- (void) testCanCreateContextForCurrentThread
 {
     NSManagedObjectContext *firstContext = [NSManagedObjectContext MR_contextForCurrentThread];
     NSManagedObjectContext *secondContext = [NSManagedObjectContext MR_contextForCurrentThread];
@@ -31,8 +37,40 @@
 - (void) testCanNotifyDefaultContextOnSave
 {
     NSManagedObjectContext *testContext = [NSManagedObjectContext MR_contextThatPushesChangesToDefaultContext];
+    
+    assertThat([testContext parentContext], is(equalTo([NSManagedObjectContext MR_defaultContext])));
+}
 
-   assertThat([testContext parentContext], is(equalTo([NSManagedObjectContext MR_defaultContext])));
+- (void)testBustedNestedContextLookup
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        assertThat([NSManagedObjectContext MR_defaultContext], is(notNilValue()));
+        
+        NSManagedObjectContext *mainContext = [NSManagedObjectContext MR_defaultContext];
+        // Create a new object
+        SingleRelatedEntity *entity = [SingleRelatedEntity createInContext:[NSManagedObjectContext MR_defaultContext]];
+        entity.mappedStringAttribute = @"test";
+        assertThat(entity, isIn([mainContext insertedObjects]));
+        
+        // Find it in the background, to do stuff to it or something
+        [MagicalRecord saveInBackgroundWithBlock:^(NSManagedObjectContext *localContext) {
+            SingleRelatedEntity *localEntity = [entity MR_inContext:localContext];
+            assertThat(localEntity, is(notNilValue()));
+            localEntity.mappedStringAttribute = @"Test";
+            
+        } completion:^{
+            dispatch_semaphore_signal(semaphore);
+            NSLog(@"Got ehre");
+        }];
+        
+    });
+    
+    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_FOREVER, 0));
+    NSLog(@"Done");
+    
+    
 }
 
 


### PR DESCRIPTION
MR_inContext won't work in child contexts if done using a temporary Id, this will try to fix that in the simple case, or at least explain it when it can't
