### PR TITLE
Allow late arriving child records to be related to correct parent

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -212,6 +212,9 @@ NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  
         {
             NSEntityDescription *entityDescription = [relationshipInfo destinationEntity];
             relatedObject = [entityDescription MR_createInstanceInContext:[self managedObjectContext]];
+            NSString *primaryKey = [relationshipInfo MR_primaryKey];
+            id relatedValue = [localObjectData MR_relatedValueForRelationship:relationshipInfo];
+            [relatedObject setValue:relatedValue forKey:primaryKey];
         }
         [relatedObject MR_importValuesForKeysWithObject:localObjectData];
         
@@ -231,6 +234,7 @@ NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  
     if (managedObject == nil) 
     {
         managedObject = [self MR_createInContext:context];
+        [managedObject setValue:value forKey:[primaryAttribute name]];
     }
 
     [managedObject MR_importValuesForKeysWithObject:objectData];


### PR DESCRIPTION
When a parent record of a to-one or to-many relationship arrives before it's child, an empty child object is created. When the child record arrives, another new object is created with no way to relate it to it's parent. By adding the primary key value when creating missing child objets they can then be found and updated when the child record arrives.
