### PR TITLE
Dynamic findBy, findAllBy, has, create

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDynamic.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDynamic.h
@@ -1,0 +1,22 @@
+//
+//  NSManagedObject+MagicalDynamic.h
+//  MagicalRecord
+//
+//  Created by Evan Cordell on 6/23/12.
+//  Copyright (c) 2012 Evan Cordell. All rights reserved.
+//
+
+#import <CoreData/CoreData.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "JRSwizzle.h"
+
+@interface NSManagedObject (Dynamic)
+
++ (id)create:(NSDictionary *)params;
++ (id)createWithBlock:(void (^) (id newObject))creationBlock;
+- (BOOL)save:(NSError **)error;
++ (id)find:(NSDictionary *)params;
++ (NSArray *)findAll:(NSDictionary *)params;
+
+@end

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDynamic.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDynamic.m
@@ -1,0 +1,143 @@
+//
+//  NSManagedObject+MagicalDynamic.m
+//  Magical Record
+//
+//  Created by Evan Cordell on 6/23/12.
+//  Copyright (c) 2012 Evan Cordell. All rights reserved.
+//
+
+#import "NSManagedObject+MagicalDynamic.h"
+
+static id dynamicFindBy(id self, SEL _cmd, NSString *string);
+static id dynamicFindAllBy(id self, SEL _cmd, NSString *string);
+static BOOL dynamicHas(id self, SEL _cmd);
+
+@implementation NSManagedObject (Dynamic)
+
++ (BOOL) swizzledResolveClassMethod:(SEL)aSEL
+{
+    Class selfMetaClass = objc_getMetaClass([NSStringFromClass([self class]) UTF8String]);
+    NSString *methodName = [NSString stringWithUTF8String:sel_getName(aSEL)];
+    
+    if ([methodName hasPrefix:@"findBy"]) {
+        class_addMethod(selfMetaClass, sel_registerName([methodName UTF8String]), (IMP) dynamicFindBy, "@@:@");
+        return YES;
+    } else if ([methodName hasPrefix:@"findAllBy"]) {
+        class_addMethod(selfMetaClass, sel_registerName([methodName UTF8String]), (IMP) dynamicFindAllBy, "@@:@");
+        return YES;
+    }
+    
+    //We only get here if an unknown method is called that doesn't start with our defined prefixes.
+    //This actually calls the *original* resolveClassMethod    
+    return [self swizzledResolveClassMethod:aSEL];
+}
+
++ (BOOL)swizzledResolveInstanceMethod:(SEL)aSEL {
+    NSString *methodName = [NSString stringWithUTF8String:sel_getName(aSEL)];
+    
+    if ([methodName hasPrefix:@"has"]) {
+        class_addMethod(self, sel_registerName([methodName UTF8String]), (IMP) dynamicHas, "@@");
+        return YES;
+    }
+    
+    //We only get here if an unknown method is called that doesn't start with our defined prefixes, or if an @dynamic property is called.
+    //This actually calls the *original* resolveInstanceMethod.
+    return [self swizzledResolveInstanceMethod:aSEL];
+}
+
++ (id)create:(NSDictionary *)params {
+    NSManagedObject *newObject = [self object];
+    for (NSString *propertyName in params) {
+        id propertyValue = [params objectForKey:propertyName];
+        SEL propertySelector = NSSelectorFromString([NSString stringWithFormat:@"set%@:", [propertyName stringByUppercasingFirstLetter], nil]);
+        if ([newObject respondsToSelector:propertySelector]) {
+            [newObject performSelector:propertySelector withObject:propertyValue];
+        }
+    }
+    return newObject;
+}
+
++ (id)createWithBlock:(void (^) (id newObject))creationBlock {
+    id newObject = [self object];    
+    creationBlock(newObject);
+    return newObject;
+}
+
+- (BOOL)save:(NSError **)error {
+    return [[[self class] currentContext] save:error];
+}
+
++ (id)find:(NSDictionary *)params {
+    //TODO: check for nil dictionary?
+    //check for existence of properties? Return nil and log error if invalid? 
+    NSString *query = @"";
+    NSString *atSign = [NSString stringWithUTF8String:"@"];
+    NSMutableArray *arguments = [NSMutableArray arrayWithCapacity:[params count]]; 
+    for (NSString *propertyName in params) {
+        id propertyValue = [params objectForKey:propertyName];
+        if (![query isEqualToString:@""]) {
+            query = [query stringByAppendingString:@" AND "];
+        }
+        query = [query stringByAppendingString:[NSString stringWithFormat:@"%@ == %%%@", propertyName, atSign]];
+        [arguments addObject:propertyValue];
+    }
+    return [self findFirstWithPredicate:[NSPredicate predicateWithFormat:query argumentArray:arguments]];
+}
+
++ (NSArray *)findAll:(NSDictionary *)params {
+    //TODO: check for nil dictionary?
+    NSString *query = @"";
+    NSString *atSign = [NSString stringWithUTF8String:"@"];
+    NSMutableArray *arguments = [NSMutableArray arrayWithCapacity:[params count]]; 
+
+    for (NSString *propertyName in params) {
+        id propertyValue = [params objectForKey:propertyName];
+        if (![query isEqualToString:@""]) {
+            query = [query stringByAppendingString:@" AND "];
+        }
+        query = [query stringByAppendingString:[NSString stringWithFormat:@"%@ == %%%@", propertyName, atSign]];
+        [arguments addObject:propertyValue];
+    }
+    return [self findAllWithPredicate:[NSPredicate predicateWithFormat:query argumentArray:arguments]];
+}
+
+@end
+
+static id dynamicFindBy(id self, SEL _cmd, NSString *string) {
+    
+    NSString *methodName = [NSString stringWithUTF8String:sel_getName(_cmd)];
+    NSRange range = NSMakeRange(6, [methodName length] - 7);
+    NSString *propertyName = [[methodName substringWithRange:range] stringByLowercasingFirstLetter];
+    
+    if (class_getProperty([self class], [propertyName UTF8String]) == NULL) {
+        return nil;
+    }
+    
+    return [self find:[NSDictionary dictionaryWithObjectsAndKeys: string, propertyName, nil]];
+}      
+
+static id dynamicFindAllBy(id self, SEL _cmd, NSString *string) {
+    
+    NSString *methodName = [NSString stringWithUTF8String:sel_getName(_cmd)];
+    NSRange range = NSMakeRange(9, [methodName length] - 10);
+    NSString *propertyName = [[methodName substringWithRange:range] stringByLowercasingFirstLetter];
+    
+    if (class_getProperty([self class], [propertyName UTF8String]) == NULL) {
+        return nil;
+    }
+    
+    return [self findAll:[NSDictionary dictionaryWithObjectsAndKeys:string, propertyName, nil]];
+}
+
+static BOOL dynamicHas(id self, SEL _cmd) {
+    NSString *methodName = [NSString stringWithUTF8String:sel_getName(_cmd)];
+    NSRange range = NSMakeRange(3, [methodName length] - 3);
+    NSString *propertyName = [[methodName substringWithRange:range] stringByLowercasingFirstLetter];
+    
+    if (class_getProperty([self class], [propertyName UTF8String])) {
+        id property = [self valueForKey:propertyName];
+        return (property) ? YES : NO;
+    }
+    
+    return NO;
+}

--- a/MagicalRecord/CoreData+MagicalRecord.h
+++ b/MagicalRecord/CoreData+MagicalRecord.h
@@ -26,6 +26,7 @@
     #import "NSManagedObject+MagicalRecord.h"
     #import "NSManagedObject+MagicalRequests.h"
     #import "NSManagedObject+MagicalFinders.h"
+    #import "NSManagedObject+MagicalDynamic.h"
     #import "NSManagedObject+MagicalAggregation.h"
     #import "NSManagedObjectContext+MagicalRecord.h"
     #import "NSManagedObjectContext+MagicalObserving.h"

--- a/Project Files/JRSwizzle.h
+++ b/Project Files/JRSwizzle.h
@@ -1,0 +1,13 @@
+// JRSwizzle.h semver:1.0
+//   Copyright (c) 2007-2011 Jonathan 'Wolf' Rentzsch: http://rentzsch.com
+//   Some rights reserved: http://opensource.org/licenses/MIT
+//   https://github.com/rentzsch/jrswizzle
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (JRSwizzle)
+
++ (BOOL)jr_swizzleMethod:(SEL)origSel_ withMethod:(SEL)altSel_ error:(NSError**)error_;
++ (BOOL)jr_swizzleClassMethod:(SEL)origSel_ withClassMethod:(SEL)altSel_ error:(NSError**)error_;
+
+@end

--- a/Project Files/JRSwizzle.m
+++ b/Project Files/JRSwizzle.m
@@ -1,0 +1,134 @@
+// JRSwizzle.m semver:1.0
+//   Copyright (c) 2007-2011 Jonathan 'Wolf' Rentzsch: http://rentzsch.com
+//   Some rights reserved: http://opensource.org/licenses/MIT
+//   https://github.com/rentzsch/jrswizzle
+
+#import "JRSwizzle.h"
+
+#if TARGET_OS_IPHONE
+	#import <objc/runtime.h>
+	#import <objc/message.h>
+#else
+	#import <objc/objc-class.h>
+#endif
+
+#define SetNSErrorFor(FUNC, ERROR_VAR, FORMAT,...)	\
+	if (ERROR_VAR) {	\
+		NSString *errStr = [NSString stringWithFormat:@"%s: " FORMAT,FUNC,##__VA_ARGS__]; \
+		*ERROR_VAR = [NSError errorWithDomain:@"NSCocoaErrorDomain" \
+										 code:-1	\
+									 userInfo:[NSDictionary dictionaryWithObject:errStr forKey:NSLocalizedDescriptionKey]]; \
+	}
+#define SetNSError(ERROR_VAR, FORMAT,...) SetNSErrorFor(__func__, ERROR_VAR, FORMAT, ##__VA_ARGS__)
+
+#if OBJC_API_VERSION >= 2
+#define GetClass(obj)	object_getClass(obj)
+#else
+#define GetClass(obj)	(obj ? obj->isa : Nil)
+#endif
+
+@implementation NSObject (JRSwizzle)
+
++ (BOOL)jr_swizzleMethod:(SEL)origSel_ withMethod:(SEL)altSel_ error:(NSError**)error_ {
+#if OBJC_API_VERSION >= 2
+	Method origMethod = class_getInstanceMethod(self, origSel_);
+	if (!origMethod) {
+#if TARGET_OS_IPHONE
+		SetNSError(error_, @"original method %@ not found for class %@", NSStringFromSelector(origSel_), [self class]);
+#else
+		SetNSError(error_, @"original method %@ not found for class %@", NSStringFromSelector(origSel_), [self className]);
+#endif
+		return NO;
+	}
+	
+	Method altMethod = class_getInstanceMethod(self, altSel_);
+	if (!altMethod) {
+#if TARGET_OS_IPHONE
+		SetNSError(error_, @"alternate method %@ not found for class %@", NSStringFromSelector(altSel_), [self class]);
+#else
+		SetNSError(error_, @"alternate method %@ not found for class %@", NSStringFromSelector(altSel_), [self className]);
+#endif
+		return NO;
+	}
+	
+	class_addMethod(self,
+					origSel_,
+					class_getMethodImplementation(self, origSel_),
+					method_getTypeEncoding(origMethod));
+	class_addMethod(self,
+					altSel_,
+					class_getMethodImplementation(self, altSel_),
+					method_getTypeEncoding(altMethod));
+	
+	method_exchangeImplementations(class_getInstanceMethod(self, origSel_), class_getInstanceMethod(self, altSel_));
+	return YES;
+#else
+	//	Scan for non-inherited methods.
+	Method directOriginalMethod = NULL, directAlternateMethod = NULL;
+	
+	void *iterator = NULL;
+	struct objc_method_list *mlist = class_nextMethodList(self, &iterator);
+	while (mlist) {
+		int method_index = 0;
+		for (; method_index < mlist->method_count; method_index++) {
+			if (mlist->method_list[method_index].method_name == origSel_) {
+				assert(!directOriginalMethod);
+				directOriginalMethod = &mlist->method_list[method_index];
+			}
+			if (mlist->method_list[method_index].method_name == altSel_) {
+				assert(!directAlternateMethod);
+				directAlternateMethod = &mlist->method_list[method_index];
+			}
+		}
+		mlist = class_nextMethodList(self, &iterator);
+	}
+	
+	//	If either method is inherited, copy it up to the target class to make it non-inherited.
+	if (!directOriginalMethod || !directAlternateMethod) {
+		Method inheritedOriginalMethod = NULL, inheritedAlternateMethod = NULL;
+		if (!directOriginalMethod) {
+			inheritedOriginalMethod = class_getInstanceMethod(self, origSel_);
+			if (!inheritedOriginalMethod) {
+				SetNSError(error_, @"original method %@ not found for class %@", NSStringFromSelector(origSel_), [self className]);
+				return NO;
+			}
+		}
+		if (!directAlternateMethod) {
+			inheritedAlternateMethod = class_getInstanceMethod(self, altSel_);
+			if (!inheritedAlternateMethod) {
+				SetNSError(error_, @"alternate method %@ not found for class %@", NSStringFromSelector(altSel_), [self className]);
+				return NO;
+			}
+		}
+		
+		int hoisted_method_count = !directOriginalMethod && !directAlternateMethod ? 2 : 1;
+		struct objc_method_list *hoisted_method_list = malloc(sizeof(struct objc_method_list) + (sizeof(struct objc_method)*(hoisted_method_count-1)));
+        hoisted_method_list->obsolete = NULL;	// soothe valgrind - apparently ObjC runtime accesses this value and it shows as uninitialized in valgrind
+		hoisted_method_list->method_count = hoisted_method_count;
+		Method hoisted_method = hoisted_method_list->method_list;
+		
+		if (!directOriginalMethod) {
+			bcopy(inheritedOriginalMethod, hoisted_method, sizeof(struct objc_method));
+			directOriginalMethod = hoisted_method++;
+		}
+		if (!directAlternateMethod) {
+			bcopy(inheritedAlternateMethod, hoisted_method, sizeof(struct objc_method));
+			directAlternateMethod = hoisted_method;
+		}
+		class_addMethods(self, hoisted_method_list);
+	}
+	
+	//	Swizzle.
+	IMP temp = directOriginalMethod->method_imp;
+	directOriginalMethod->method_imp = directAlternateMethod->method_imp;
+	directAlternateMethod->method_imp = temp;
+	
+	return YES;
+#endif
+}
+
++ (BOOL)jr_swizzleClassMethod:(SEL)origSel_ withClassMethod:(SEL)altSel_ error:(NSError**)error_ {
+	return [GetClass((id)self) jr_swizzleMethod:origSel_ withMethod:altSel_ error:error_];
+}
+
+@end

--- a/Project Files/Magical Record.xcodeproj/project.pbxproj
+++ b/Project Files/Magical Record.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2056AF3615DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m in Sources */ = {isa = PBXBuildFile; fileRef = 2056AF3415DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m */; };
+		2056AF3715DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m in Sources */ = {isa = PBXBuildFile; fileRef = 2056AF3415DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m */; };
+		2056AF3B15DC61EF00D98F60 /* JRSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 2056AF3A15DC61EF00D98F60 /* JRSwizzle.m */; };
+		2056AF3C15DC61EF00D98F60 /* JRSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 2056AF3A15DC61EF00D98F60 /* JRSwizzle.m */; };
 		C70B6E7113D0F62500709450 /* NSPersisentStoreHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C70B6E7013D0F62500709450 /* NSPersisentStoreHelperTests.m */; };
 		C70B6E7413D0F64000709450 /* NSPersistentStoreCoordinatorHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C70B6E7313D0F64000709450 /* NSPersistentStoreCoordinatorHelperTests.m */; };
 		C70B6E7713D0F66000709450 /* NSManagedObjectModelHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C70B6E7613D0F66000709450 /* NSManagedObjectModelHelperTests.m */; };
@@ -234,6 +238,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2056AF3415DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+MagicalDynamic.m"; sourceTree = "<group>"; };
+		2056AF3515DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+MagicalDynamic.h"; sourceTree = "<group>"; };
+		2056AF3915DC61EF00D98F60 /* JRSwizzle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JRSwizzle.h; sourceTree = "<group>"; };
+		2056AF3A15DC61EF00D98F60 /* JRSwizzle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JRSwizzle.m; sourceTree = "<group>"; };
 		C70B6E6F13D0F62500709450 /* NSPersisentStoreHelperTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSPersisentStoreHelperTests.h; path = "Unit Tests/NSPersisentStoreHelperTests.h"; sourceTree = "<group>"; };
 		C70B6E7013D0F62500709450 /* NSPersisentStoreHelperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSPersisentStoreHelperTests.m; path = "Unit Tests/NSPersisentStoreHelperTests.m"; sourceTree = "<group>"; };
 		C70B6E7213D0F64000709450 /* NSPersistentStoreCoordinatorHelperTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSPersistentStoreCoordinatorHelperTests.h; path = "Unit Tests/NSPersistentStoreCoordinatorHelperTests.h"; sourceTree = "<group>"; };
@@ -685,6 +693,8 @@
 		C7C9A37013F43D3E002C5B0C /* Third Party */ = {
 			isa = PBXGroup;
 			children = (
+				2056AF3915DC61EF00D98F60 /* JRSwizzle.h */,
+				2056AF3A15DC61EF00D98F60 /* JRSwizzle.m */,
 				C7C9A37113F43D93002C5B0C /* JSONKit.h */,
 				C7C9A37213F43D93002C5B0C /* JSONKit.m */,
 			);
@@ -742,6 +752,8 @@
 		C7DD72AA150F832A00216827 /* NSManagedObject */ = {
 			isa = PBXGroup;
 			children = (
+				2056AF3415DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m */,
+				2056AF3515DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.h */,
 				C7DD72AB150F832A00216827 /* NSManagedObject+MagicalAggregation.h */,
 				C7DD72AC150F832A00216827 /* NSManagedObject+MagicalAggregation.m */,
 				C7DD72AD150F832A00216827 /* NSManagedObject+MagicalDataImport.h */,
@@ -1042,6 +1054,8 @@
 				C7DD7303150F832B00216827 /* MagicalRecord+Setup.m in Sources */,
 				C7DD7305150F832B00216827 /* MagicalRecord+ShorthandSupport.m in Sources */,
 				C7DD7307150F832B00216827 /* MagicalRecord.m in Sources */,
+				2056AF3615DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m in Sources */,
+				2056AF3B15DC61EF00D98F60 /* JRSwizzle.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1116,6 +1130,8 @@
 				C7DD7304150F832B00216827 /* MagicalRecord+Setup.m in Sources */,
 				C7DD7306150F832B00216827 /* MagicalRecord+ShorthandSupport.m in Sources */,
 				C7DD7308150F832B00216827 /* MagicalRecord.m in Sources */,
+				2056AF3715DC61AF00D98F60 /* NSManagedObject+MagicalDynamic.m in Sources */,
+				2056AF3C15DC61EF00D98F60 /* JRSwizzle.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This pull request adds a new category to NSManagedObject so that any subclass can call methods of the form

`[MyManagedObject findByName:@"Foo"]`

and 

`[MyManagedObject findAllByUuid:@"F_b_o_a_o_r"]`

It also works for any subclass of NSManagedObject, and returns nil if the property does not exist in the class.

It also adds some other ActiveRecord-like features. There are two new ways to create records: with a dictionary and with a block.

```
Record *newRecord = [Record create:@{@"name" : @"Squash", @"type": @"Vegetable"}];
```

And with a block (requires LLVM >=3.1):

```
Record *newRecord = [Record createWithBlock:^(Record *n) {
        n.name = @"Onion";
        n.type = @"Vegetable";
}];
```

There's a new save method that you can call on an instance of a class rather than the class:

```
[newRecord save:&error];
```

In addition to the dynamic findBy and findAllBy methods, there are now find and findAll methods that take an NSDictionary:

```
Record *record = [Record find:@{ @"name" : @"Apple", @"type" : @"Fruit" }];
```

These methods will hopefully help build dynamic findBy methods with multiple paramaters.

There's also a findOrCreate, which returns an object with the given properties if one exists, and creates one if it does not

```
Record *newRecord = [Record findOrCreate:@{ @"name" : @"Mango", @"type" : @"Fruit" }];
```

I've also added dynamic hasProperty methods:

```
Record *newRecord = [Record create:[NSDictionary dictionaryWithObjectsAndKeys:@"Squash", @"name", nil]];
NSLog(@"%@", [newRecord hasName] ? @"YES" : @"NO");  //Prints YES
NSLog(@"%@", [newRecord hasType] ? @"YES" : @"NO");  //Prints NO
```

**_But Why?**_
ActiveRecord is awesome, and I felt that MagicalRecord didn't quite capture the magic, no pun intended. 

Originally I wrote this as an extension of RestKit's Core Data extensions, but those were mostly copied/pasted from this project anyway. 

**_How it Works**_
It's actually pretty cool: any time a selector is sent to a class that the class doesn't recognize, `resolveInstanceMethod:` or `resolveClassMethod:` gets called. 

You can't just "override" a method in a category, though. To get around this, I swizzle the methods so that my implementation of resolveClassMethod gets called instead. And I'm using JRSwizzle to do this, so everything is  fine with inheritance and whatnot. If the method exists already (or doesn't start with findBy or findAllBy), I swizzle 'em back and pass the selector back to the normal resolveClassMethod:.

**_What's left to do**_
- Find a way to quiet the "might not respond to selector" warnings. (This seems to be impossible at the moment - I think simply adding declarations for the methods that you use will fix it.)
- Allow uppercase properties. Right now it assumes a camel-cased property with a lowercase first letter.
- Allow multiple parameters, i. e. `[MyManagedObject findByCategory: @"Fruit" color:@"Red"];`
- Test it. I've tested on the simulator in an actual app, but I haven't yet written unit tests.

Since I wrote this originally for RestKit, I'm unfamiliar with the conventions for this project. I assume everything should be unit tested? I assume I need to prefix everything with MR_? I wanted to go ahead and send a pull request with these ideas to see if this is something that should even be added to the project. If so, I'll tie up all of the loose ends.

NOTE: I haven't actually tried using this code in MagicalRecord. I suspect it doesn't work out of the box. As I said, just wanted to put out some feelers here and see if I should finish it up. (And it _did_ work in RestKit)
