### PR TITLE
Fixed crashing when importing data with a different than expected type

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -51,7 +51,12 @@ NSString * const kMagicalRecordImportRelationshipTypeKey            = @"type";  
             id value = [attributeInfo MR_valueForKeyPath:lookupKeyPath fromObjectData:objectData];
             if (![self MR_importValue:value forKey:attributeName])
             {
-                [self setValue:value forKey:attributeName];
+				@try {
+					[self setValue:value forKey:attributeName];
+				}
+				@catch (NSException *exception) {
+					NSLog(@"Couldn't import value: %@", exception.reason);
+				}
             }
         }
     }


### PR DESCRIPTION
Hi!

Started using MagicalImport on a new project and run into an error: when importing data with another type than it is expected in the entity's setter an exception is thrown - for example, if you put `NSNumber` into `- (void)setTitle:(NSString *)title`. It would be good to check such kind of errors when importing data from REST API. Changing the data type on the server side would crash the whole app.

I've added try-catch block on setting KVC value. I doubt that it is the best implementation regarding performance issues but it solves the problem.

Would like to hear your thoughts on this.

Thank you.
