### PR TITLE
Pull Request: Added MR_Safe_Set define option for additional (optional) attribute type checks.

### DIFF
--- a/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
@@ -41,6 +41,27 @@
             }
             value = adjustDateForDST(value);
         }
+        
+    #ifdef MR_SAFE_SET        
+        else if (((attributeType == NSInteger16AttributeType) ||
+                  (attributeType == NSInteger32AttributeType) ||
+                  (attributeType == NSInteger64AttributeType) ||
+                  (attributeType == NSBooleanAttributeType))
+                 && ([value isKindOfClass:[NSString class]]))
+        {
+            value = [NSNumber numberWithInteger:[value  integerValue]];
+        }
+        else if (((attributeType == NSFloatAttributeType) || (attributeType == NSDoubleAttributeType))
+                 && ([value isKindOfClass:[NSString class]]))
+        {
+            value = [NSNumber numberWithDouble:[value doubleValue]];
+        }
+        else if ((attributeType == NSStringAttributeType) && ([value isKindOfClass:[NSNumber class]]))
+        {
+            value = [value stringValue];
+        }        
+    #endif
+        
     }
     
     return value == [NSNull null] ? nil : value;   


### PR DESCRIPTION
Added MR_Safe_Set define option. To use, #define MR_SAFE_Set 1. This add adds additional type checks prior to setting value for key.
