### PR TITLE
aggregateOperation not performed inContext correctly

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
@@ -123,7 +123,7 @@
     [request setPropertiesToFetch:properties];
     [request setResultType:NSDictionaryResultType];    
     
-    NSDictionary *resultsDictionary = [self MR_executeFetchRequestAndReturnFirstObject:request];
+    NSDictionary *resultsDictionary = [self MR_executeFetchRequestAndReturnFirstObject:request inContext:context];
     NSNumber *resultValue = [resultsDictionary objectForKey:@"result"];
     
     return resultValue;    


### PR DESCRIPTION
Small bug with aggregateOperation not being performed in the context correctly.  It creates some objects in the specified context, some in the thread context.  Pretty straight forward bug, but it keeps me from using the function since we rarely perform change operations on the main thread.
