### PR TITLE
Obtain permanent IDs on inserted objects before saving

### DIFF
--- a/MagicalRecord/Core/MagicalRecordNestedContextsPersistenceStrategy.m
+++ b/MagicalRecord/Core/MagicalRecordNestedContextsPersistenceStrategy.m
@@ -17,6 +17,8 @@
     NSManagedObjectContext *defaultContext = [NSManagedObjectContext MR_newMainQueueContext];
     [defaultContext setParentContext:rootContext];
     [NSManagedObjectContext MR_setDefaultContext:defaultContext];
+    [NSManagedObjectContext MR_makeContextObtainPermanentIDsBeforeSaving:defaultContext];
+        [NSManagedObjectContext MR_makeContextObtainPermanentIDsBeforeSaving:rootContext];
     [NSManagedObjectContext MR_makeContext:rootContext mergeChangesToContext:defaultContext];
 }
 

--- a/MagicalRecord/Core/MagicalRecordParallelStoresPersistenceStrategy.m
+++ b/MagicalRecord/Core/MagicalRecordParallelStoresPersistenceStrategy.m
@@ -33,7 +33,8 @@
     // Use the coordinator passed in
     [defaultContext setPersistentStoreCoordinator:coordinator];
     [NSManagedObjectContext MR_setDefaultContext:defaultContext];
-
+    [NSManagedObjectContext MR_makeContextObtainPermanentIDsBeforeSaving:defaultContext];
+    [NSManagedObjectContext MR_makeContextObtainPermanentIDsBeforeSaving:rootContext];
     [NSManagedObjectContext MR_makeContext:rootContext mergeChangesToContext:defaultContext];
     [NSManagedObjectContext MR_makeContext:defaultContext mergeChangesToContext:rootContext];
 }


### PR DESCRIPTION
This will fix many cases of object relationships being busted, strange crashes, and much bad behavior
