### PR TITLE
added specific column sort ability to fetch methods

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -115,7 +115,18 @@
     NSArray* sortKeys = [sortTerm componentsSeparatedByString:@","];
     for (NSString* sortKey in sortKeys) 
     {
-        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        BOOL scopeAscending = ascending;
+        NSString *scopeSortKey = sortKey;
+        if ([sortKey rangeOfString:@" ASC"].location != NSNotFound) {
+            scopeAscending = YES;
+            scopeSortKey = [sortKey stringByReplacingOccurrencesOfString:@" ASC" withString:@""];
+        }
+        else if ([sortKey rangeOfString:@" DESC"].location != NSNotFound) {
+            scopeAscending = NO;
+            scopeSortKey = [sortKey stringByReplacingOccurrencesOfString:@" DESC" withString:@""];
+        }
+        
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:scopeSortKey ascending:scopeAscending];
         [sortDescriptors addObject:sortDescriptor];
     }
     


### PR DESCRIPTION
I spent some time dealing with the fetch methods sorting implementation to be able to sort one column ascending and another one descending and found out that I could not do this without changing MagicalRecord fetch code itself.

The current implementation uses the sorting _NSString_ and splits it by comas to create a _NSSortDescriptor_ for each column, using the _ascending_ flag for all of them, so all columns would have the same sort order.

I don't know a better way to change the fetch methods implementation without breaking everything else, so while trying to change as little as possible and also keeping backwards compatibility, I added the _ASC_ and _DESC_ check for each column sent as sort key, then I change its sort order accordingly, ignoring the _ascending_ flag if it matches an _ASC_ or _DESC_ string in the end of the column name.

So, you could pass @"column1,column2 DESC" as _sortTerm_ , which would make _column2_ to have a descent order when performing the fetch, regardless of the _ascending_ flag value passed to the fetch request.
