### PR TITLE
Removes dispatch_release when iOS >= 6 || OSX >= 1080

### DIFF
--- a/MagicalRecord/Core/MagicalRecord+Actions.m
+++ b/MagicalRecord/Core/MagicalRecord+Actions.m
@@ -26,7 +26,7 @@ void reset_action_queue(void)
 {
     if (background_action_queue != NULL)
     {
-        //        dispatch_release(background_action_queue);
+        MRDispatchQueueRelease(background_action_queue);
         background_action_queue = NULL;
     }
 }

--- a/MagicalRecord/CoreData+MagicalRecord.h
+++ b/MagicalRecord/CoreData+MagicalRecord.h
@@ -45,3 +45,16 @@
     #import "NSEntityDescription+MagicalDataImport.h"
 
 #endif
+
+// @see https://github.com/ccgus/fmdb/commit/aef763eeb64e6fa654e7d121f1df4c16a98d9f4f
+#define MRDispatchQueueRelease(q) (dispatch_release(q))
+
+#if TARGET_OS_IPHONE
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+        #define MRDispatchQueueRelease(q)
+    #endif
+#else
+    #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+        #define MRDispatchQueueRelease(q)
+    #endif
+#endif


### PR DESCRIPTION
`dispatch_release` is forbidden under ARC in new iOS and OSX versions

Instead of commenting out `dispatch_release` we could define an empty macro to support other iOS versions.

@see https://github.com/ccgus/fmdb/commit/aef763eeb64e6fa654e7d121f1df4c16a98d9f4f via @JHumphreyJr in https://github.com/Nyx0uf/NYXImagesKit/issues/16
