### PR TITLE
Require ARC in podspec

### DIFF
--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
+  s.requires_arc = true
 
   def s.post_install(target)
     prefix_header = config.project_pods_root + target.prefix_header_filename


### PR DESCRIPTION
Installing MR via cocoapods was not enabling ARC on compiled files, resulting in memory problems.
