### PR TITLE
Update tag in podspec to 2.0.6

### DIFF
--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name     = 'MagicalRecord'
-  s.version  = '2.0.5'
+  s.version  = '2.0.6'
   s.license  = 'MIT'
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.5' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.6' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'


### PR DESCRIPTION
The podspec here was still on 2.0.5. It's updated to 2.0.6 and matches what's been committed to CocoaPods/Specs repo. Cheers.
