### PR TITLE
allow multi-level key paths for relationship mappedKeyName

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -137,7 +137,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         NSRelationshipDescription *relationshipInfo = [relationships valueForKey:relationshipName];
         
         NSString *lookupKey = [[relationshipInfo userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
-        id relatedObjectData = [relationshipData valueForKey:lookupKey];
+        id relatedObjectData = [relationshipData valueForKeyPath:lookupKey];
         
         if (relatedObjectData == nil || [relatedObjectData isEqual:[NSNull null]]) 
         {


### PR DESCRIPTION
I had the impression from Saul's blog post that mappedKeyName could be a full key path, not just a key, but valueForKey: is being used in MR_setRelationships:forKeysWithObject:withBlock:. Switched to valueForKeyPath:.

This allows you to actually use a multi-level key path for mappedKeyName for a relationship.
