### PR TITLE
Added support for "stub" objects created from imported JSON

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -72,16 +72,24 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 {
     NSEntityDescription *destinationEntity = [relationshipInfo destinationEntity];
     NSManagedObject *objectForRelationship = nil;
+
     id relatedValue;
-    if ([singleRelatedObjectData isKindOfClass:[NSDictionary class]])
-    {
-        relatedValue = [singleRelatedObjectData MR_relatedValueForRelationship:relationshipInfo];
-    }
-    else
+
+    // if its a primitive class, than handle singleRelatedObjectData as the key for relationship
+    if ([singleRelatedObjectData isKindOfClass:[NSString class]] ||
+        [singleRelatedObjectData isKindOfClass:[NSNumber class]])
     {
         relatedValue = singleRelatedObjectData;
     }
-    
+    else if ([singleRelatedObjectData isKindOfClass:[NSDictionary class]])
+	{
+		relatedValue = [singleRelatedObjectData MR_relatedValueForRelationship:relationshipInfo];
+	}
+	else
+    {
+        relatedValue = singleRelatedObjectData;
+    }
+
     if (relatedValue)
     {
         NSManagedObjectContext *context = [self managedObjectContext];


### PR DESCRIPTION
When the object import runs and the JSON contains only an object ID for
a child object, currently nothing happens. This change will create a
new object and set up the relationship with the ID set and the rest of
the attributes to their default values. When future imports happen and
more detail is gathered for these child objects, the stub objects can
then be fleshed out and those relationships are already set.

Without this, you may miss out on that relationship data that was
attempted to be set in the first import, and when the details are added
we don't know how the object map fits together.
