### PR TITLE
Make saveWithBlock: use saveNestedContexts

### DIFF
--- a/MagicalRecord/Core/MagicalRecord+Actions.m
+++ b/MagicalRecord/Core/MagicalRecord+Actions.m
@@ -39,17 +39,11 @@
     NSManagedObjectContext *mainContext  = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextWithParent:mainContext];
 
-    block(localContext);
-    
-    if ([localContext hasChanges]) 
-    {
-        [localContext MR_saveNestedContextsErrorHandler:errorHandler];
-    }
-    
-    if (completion)
-    {
-        dispatch_async(dispatch_get_main_queue(), completion);
-    }
+    [localContext performBlockAndWait: ^{
+        block(localContext);
+
+        [localContext MR_saveNestedContextsErrorHandler:errorHandler completion:completion];
+    }];
 }
 
 + (void) saveWithBlock:(void(^)(NSManagedObjectContext *localContext))block


### PR DESCRIPTION
As you maybe know I was having quite some trouble with MagicalRecord and having it persist my data to disk. (See issue #314.) As it turns out I made some mistakes myself, but there is also an inconsistency between `saveWithBlock:` and `saveInBackgroundWithBlock:`.

The `saveInBackgroundWithBlock:` is using the `saveNestedContexts` methods and is persisting stuff to disk as expected, but when I switched to `saveWithBlock:` I lost data because it was using the not nested `save` methods.

In my opinion the behavior should be consistent to prevent confusing people (like me) and losing their data.

I hope one of the devs has some time to pull this in and save me and other a lot of time hunting down persistence issues. If there is anything I should change or improve before pulling these commits in let me know!
