### PR TITLE
Pull request for inContext TemporaryID problem

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -222,6 +222,19 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 - (id) MR_inContext:(NSManagedObjectContext *)otherContext
 {
     NSError *error = nil;
+    
+    if(self.objectID.isTemporaryID)
+    {
+        BOOL success = [self.managedObjectContext obtainPermanentIDsForObjects:@[self]
+                                                                         error:&error];
+        if (!success)
+        {
+            [MagicalRecord handleErrors:error];
+        }
+    }
+    
+    error = nil;
+    
     NSManagedObject *inContext = [otherContext existingObjectWithID:[self objectID] error:&error];
     [MagicalRecord handleErrors:error];
     


### PR DESCRIPTION
Fixes a problem where a newly created & saved object in another context
still has a temporary ID assigned to it.
