### PR TITLE
- (void)deleteObjectsInArray:(NSArray *)managedObjects; convenience method

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
@@ -25,6 +25,8 @@ extern NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification;
 - (NSString *) MR_description;
 - (NSString *) MR_parentChain;
 
+- (void) MR_deleteObjectsInArray:(NSArray *)managedObjects;
+
 @property (nonatomic, copy, setter = MR_setWorkingName:) NSString *MR_workingName;
 
 @end

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -227,5 +227,12 @@ static NSString * const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSM
     return workingName;
 }
 
+- (void)MR_deleteObjectsInArray:(NSArray *)managedObjects
+{
+    for (NSManagedObject *managedObject in managedObjects)
+    {
+        [self deleteObject:managedObject];
+    }
+}
 
 @end

--- a/MagicalRecord/Core/MagicalRecordShorthand.h
+++ b/MagicalRecord/Core/MagicalRecordShorthand.h
@@ -130,6 +130,7 @@
 + (NSManagedObjectContext *) defaultContext;
 + (void) cleanUp;
 - (NSString *) description;
+- (void) deleteObjectsInArray:(NSArray *)managedObjects;
 @end
 @interface NSManagedObjectContext (MagicalSavesShortHand)
 - (void) save;


### PR DESCRIPTION
I thought this was a useful addition to NSManagedObjectContext to perform a common operation.

The API is similar to how NSMutableArray has both 'removeObject' and 'removeObjectsInArray' methods.
