### PR TITLE
Added additional case that will trigger persistant store cleanup

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -77,7 +77,8 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
     
     if (!store && [MagicalRecord shouldDeleteStoreOnModelMismatch])
     {
-        if ([[error domain] isEqualToString:NSCocoaErrorDomain] && [error code] == NSPersistentStoreIncompatibleVersionHashError)
+        BOOL isMigrationError = [error code] == NSPersistentStoreIncompatibleVersionHashError || [error code] == NSMigrationMissingSourceModelError;
+        if ([[error domain] isEqualToString:NSCocoaErrorDomain] && isMigrationError)
         {
             // Could not open the database, so... kill it!
             [[NSFileManager defaultManager] removeItemAtURL:url error:nil];

--- a/Project Files/Magical Record.xcodeproj/xcshareddata/xcschemes/Mac Unit Tests.xcscheme
+++ b/Project Files/Magical Record.xcodeproj/xcshareddata/xcschemes/Mac Unit Tests.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
I added NSMigrationMissingSourceModelError to the list of things that can trigger deleting the store (if the configuration option is set)
