### PR TITLE
Incorrect date timezone assumption while importing

### DIFF
--- a/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
+++ b/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
@@ -34,7 +34,7 @@ NSDate * adjustDateForDST(NSDate *date)
 NSDate * dateFromString(NSString *value, NSString *format)
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setTimeZone:[NSTimeZone localTimeZone]];
+    [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
     [formatter setLocale:[NSLocale currentLocale]];
     [formatter setDateFormat:format];
     


### PR DESCRIPTION
The server returns data using GMT ("Zulu"-time). Setting the formatter's timezone to local adjusts the time to the local time which results in an incorrect date.

This was also failing the unit test. This fixes the basic bug. A slightly larger feature/fix could allow  adjusting the timezone by allowing a timeZone attribute in the data model.
