### PR TITLE
Fix dot-syntax message inconsistency.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -72,7 +72,7 @@
 {
     [self performBlock:^{
         [self MR_saveWithErrorCallback:errorCallback];
-        if (self.parentContext) {
+        if ([self parentContext]) {
             [[self parentContext] performBlock:^{
                 [[self parentContext] MR_saveNestedContextsErrorHandler:errorCallback completion:completion];
             }];


### PR DESCRIPTION
Property dot-syntax used for non-property method despite different
syntax used in the same method.
