### PR TITLE
Error handler was ignored in MR_saveNestedContextsErrorHandler:

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -65,7 +65,7 @@
 
 - (void) MR_saveNestedContextsErrorHandler:(void (^)(NSError *))errorCallback;
 {
-    [self MR_saveNestedContextsErrorHandler:nil completion:nil];
+    [self MR_saveNestedContextsErrorHandler:errorCallback completion:nil];
 }
 
 - (void) MR_saveNestedContextsErrorHandler:(void (^)(NSError *))errorCallback completion:(void (^)(void))completion;


### PR DESCRIPTION
I noticed this while perusing the class, a simple fix to `MR_saveNestedContextsErrorHandler:` which was not using the provided error handler.
