### PR TITLE
Added find and delete methods that creates a where clause based on a dictionary of attributes and values.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -19,8 +19,9 @@
 
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
-+ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;
-+ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
+
++ (NSArray *) MR_findAllByAttributesAndValues:(NSDictionary *)attributesAndValues;
++ (NSArray *) MR_findAllByAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
 
 + (id) MR_findFirst;
 + (id) MR_findFirstInContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -19,6 +19,8 @@
 
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
++ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;
++ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
 
 + (id) MR_findFirst;
 + (id) MR_findFirstInContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -74,13 +74,13 @@
                                inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
-+ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues
++ (NSArray *) MR_findAllByAttributesAndValues:(NSDictionary *)attributesAndValues
 {
-    return [self MR_FindAllMatchingDictionaryOfAttributesAndValues:attributesAndValues
+    return [self MR_findAllByAttributesAndValues:attributesAndValues
                                                          inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
-+ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
++ (NSArray *) MR_findAllByAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
 {
     NSMutableArray *predicates = [NSMutableArray array];
     for (NSString *key in [attributesAndValues allKeys]) {

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -74,6 +74,24 @@
                                inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
++ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues
+{
+    return [self MR_FindAllMatchingDictionaryOfAttributesAndValues:attributesAndValues
+                                                         inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+}
+
++ (NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
+{
+    NSMutableArray *predicates = [NSMutableArray array];
+    for (NSString *key in [attributesAndValues allKeys]) {
+        id value = [attributesAndValues objectForKey:key];
+        [predicates addObject:[NSPredicate predicateWithFormat:@"%K = %@", key,value]];
+    }
+    NSPredicate *finalPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:predicates];
+    
+    return [self MR_findAllWithPredicate:finalPredicate inContext:context];
+}
+
 + (id) MR_findFirstInContext:(NSManagedObjectContext *)context
 {
 	NSFetchRequest *request = [self MR_createFetchRequestInContext:context];

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -37,8 +37,8 @@
 + (BOOL) MR_deleteAllMatchingPredicate:(NSPredicate *)predicate;
 + (BOOL) MR_deleteAllMatchingPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 
-+ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
-+ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;
++ (BOOL) MR_deleteAllByAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;                           
++ (BOOL) MR_deleteAllByAttributesAndValues:(NSDictionary *)attributesAndValues;
 
 + (BOOL) MR_truncateAll;
 + (BOOL) MR_truncateAllInContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -37,6 +37,9 @@
 + (BOOL) MR_deleteAllMatchingPredicate:(NSPredicate *)predicate;
 + (BOOL) MR_deleteAllMatchingPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 
++ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
++ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;
+
 + (BOOL) MR_truncateAll;
 + (BOOL) MR_truncateAllInContext:(NSManagedObjectContext *)context;
 

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -203,11 +203,11 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     return [self MR_deleteAllMatchingPredicate:predicate inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
-+ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
++ (BOOL) MR_deleteAllByAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
 {
-    
     NSMutableArray *predicates = [NSMutableArray array];
-    for (NSString *key in [attributesAndValues allKeys]) {
+    for (NSString *key in [attributesAndValues allKeys])
+    {
         id value = [attributesAndValues objectForKey:key];
         [predicates addObject:[NSPredicate predicateWithFormat:@"%K = %@", key,value]];
     }
@@ -216,10 +216,10 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     return [self MR_deleteAllMatchingPredicate:finalPredicate inContext:context];
 }
 
-+ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues
++ (BOOL) MR_deleteAllByAttributesAndValues:(NSDictionary *)attributesAndValues
 {
     
-    return [self MR_deleteAllMatchingDictionaryOfAttributesAndValues:attributesAndValues
+    return [self MR_deleteAllByAttributesAndValues:attributesAndValues
                                                            inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -203,6 +203,26 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     return [self MR_deleteAllMatchingPredicate:predicate inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
 }
 
++ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context
+{
+    
+    NSMutableArray *predicates = [NSMutableArray array];
+    for (NSString *key in [attributesAndValues allKeys]) {
+        id value = [attributesAndValues objectForKey:key];
+        [predicates addObject:[NSPredicate predicateWithFormat:@"%K = %@", key,value]];
+    }
+    NSPredicate *finalPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:predicates];
+    
+    return [self MR_deleteAllMatchingPredicate:finalPredicate inContext:context];
+}
+
++ (BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues
+{
+    
+    return [self MR_deleteAllMatchingDictionaryOfAttributesAndValues:attributesAndValues
+                                                           inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+}
+
 + (BOOL) MR_truncateAllInContext:(NSManagedObjectContext *)context
 {
     NSArray *allEntities = [self MR_findAllInContext:context];


### PR DESCRIPTION
With literals being available now for dictionaries it is super handy to do make a query return on a nice clean dictionary of key value pairs. This compliments the existing find/delete by attribute methods. Examples of use:
[SomeClass MR_deleteAllMatchingDictionaryOfAttributesAndValues:@{@"firstName" : @"Gary", @"lastName" : @"Tubbs"}];
NSArray *results = [SomeClass MR_FindAllMatchingDictionaryOfAttributesAndValues:@{@"firstName" : @"Gary", @"lastName" : @"Tubbs"}];

Added:

(NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;
(NSArray *) MR_FindAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
(BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues inContext:(NSManagedObjectContext *)context;
(BOOL) MR_deleteAllMatchingDictionaryOfAttributesAndValues:(NSDictionary *)attributesAndValues;