### PR TITLE
Add method to clear thread-local context

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.h
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.h
@@ -12,5 +12,6 @@
 
 + (NSManagedObjectContext *) MR_contextForCurrentThread;
 + (void) MR_resetContextForCurrentThread;
++ (void) MR_clearContextForCurrentThread;
 
 @end

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
@@ -38,4 +38,8 @@ static NSString const * kMagicalRecordManagedObjectContextKey = @"MagicalRecord_
 	}
 }
 
++ (void) MR_clearContextForCurrentThread {
+    [[[NSThread currentThread] threadDictionary] removeObjectForKey:kMagicalRecordManagedObjectContextKey];
+}
+
 @end


### PR DESCRIPTION
When running unit tests that are asynchronous/multi-threaded, I find that oftentimes a background thread will have an `NSManagedObjectContext` instance (created by `MR_contextForCurrentThread`) from a previous set up, even after calling `[MagicalRecord cleanUp]`

When this happens, I get the dreaded "Object's persistent store is not reachable from this NSManagedObjectContext's coordinator" error. Removing the MOC's from each thread's `threadDictionary` solves the problem.
