### PR TITLE
MR_importFromArray:inContext: returns empty

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -261,7 +261,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 {
     NSMutableArray *objectIDs = [NSMutableArray array];
     
-    [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) 
+    [MagicalRecord saveWithBlockAndWait:^(NSManagedObjectContext *localContext)
     {    
         [listOfObjectData enumerateObjectsWithOptions:0 usingBlock:^(id obj, NSUInteger idx, BOOL *stop) 
         {


### PR DESCRIPTION
...omArray: not to return before objects are imported.

I had the issue that the returned array of imported objects was empty. On further investigation it seems the last method `MR_findAllWithPredicate:inContext:` is executed before the `saveWithBlock:` method is finished and therefore the `objectIDs` array is not yet filled for the last method. One solution I found to work was to change
`saveWithBlock:`
to
`saveWithBlockAndWait:`.

Alternatively the `saveWithBlock:` method could be removed completely as the single object import `MR_importFromObject:inContext:` is also not saving.

Hope I got it right, below is the method I use, that returns a filled array of imported objects.

```
+ (NSArray *) MR_importFromArray:(NSArray *)listOfObjectData inContext:(NSManagedObjectContext *)context
{
    NSMutableArray *objectIDs = [NSMutableArray array];

    [MagicalRecord saveWithBlockAndWait:^(NSManagedObjectContext *localContext)
     {
         [listOfObjectData enumerateObjectsWithOptions:0 usingBlock:^(id obj, NSUInteger idx, BOOL *stop)
          {
              NSDictionary *objectData = (NSDictionary *)obj;

              NSManagedObject *dataObject = [self MR_importFromObject:objectData inContext:localContext];

              if ([context obtainPermanentIDsForObjects:[NSArray arrayWithObject:dataObject] error:nil])
              {
                  [objectIDs addObject:[dataObject objectID]];
              }
          }];
     }];

    return [self MR_findAllWithPredicate:[NSPredicate predicateWithFormat:@"self IN %@", objectIDs] inContext:context];
}
```
