### PR TITLE
NSPersistentStore+MagicalRecord.m - Default storage-type on iOS

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
@@ -56,7 +56,11 @@ static NSPersistentStore *defaultPersistentStore_ = nil;
     }
 
     //set default url
+#if TARGET_OS_IPHONE
+    return [NSURL fileURLWithPath:[[self MR_applicationDocumentsDirectory] stringByAppendingPathComponent:storeFileName]];
+#else
     return [NSURL fileURLWithPath:[[self MR_applicationStorageDirectory] stringByAppendingPathComponent:storeFileName]];
+#endif
 }
 
 + (NSURL *) MR_cloudURLForUbiqutiousContainer:(NSString *)bucketName;


### PR DESCRIPTION
When using the [MagicalRecord coordinatorWithAutoMigratingSqliteStoreNamed:] method my Database.sqlite will be incorrectly saved in a sub-folder tree inside my documents folder, this is due to using the MR_applicationStorageDirectory, this will be ok for Mac OS X but for iOS I expect the files to reside in the MR_applicationDocumentsDirectory so my Database.sqlite get's backed up.
