### PR TITLE
When saving a context, execute the completion block on the calling thread

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -74,9 +74,7 @@
                 [MagicalRecord handleErrors:error];
 
                 if (completion) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        completion(saved, error);
-                    });
+                    completion(saved, error);
                 }
             } else {
                 // If we're the default context, save to disk too (the user expects it to persist)
@@ -92,9 +90,7 @@
                     MRLog(@"→ Finished saving: %@", [self MR_description]);
 
                     if (completion) {
-                        dispatch_async(dispatch_get_main_queue(), ^{
-                            completion(saved, error);
-                        });
+                        completion(saved, error);
                     }
                 }
             }


### PR DESCRIPTION
MR_saveWithOptions:completion: currently dispatches the completion block to execute asynchronously on the main thread. This has 2 negative effects:

1) Because it's asynchronous, it prevents the caller from handling errors appropriately in the callback. If there's an error on save, the caller should have the flexibility to bail or reset the context.

2) Because it's executed on the main thread, a caller on a background thread cannot include code in the callback that must also be executed on the background thread.

It's trivial for the caller to include a dispatch_async(dispatch_get_main_queue(), ^{}) inside their completion block if that's the desired behavior, but the API shouldn't make that assumption for them.
