### PR TITLE
Ordered child relationship fails in DataImport.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -101,8 +101,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         if ([relationshipInfo respondsToSelector:@selector(isOrdered)] && [relationshipInfo isOrdered])
         {
             //Need to get the ordered set
-            NSString *selectorName = [[relationshipInfo name] stringByAppendingString:@"Set"];
-            relationshipSource = [self performSelector:NSSelectorFromString(selectorName)];
+            relationshipSource = [self performSelector:NSSelectorFromString([relationshipInfo name])];
             addRelationMessageFormat = @"addObject:";
         }
     }


### PR DESCRIPTION
DataImport was failing when a ordered one to many child relationship was being processed.  Previously, the importer was calling (ex: relationship name was say videos) videosSet instead of just videos, fixed now and will just call videos
