### PR TITLE
MR_fetchAllGroupedBy method performs double fetch

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -320,15 +320,12 @@
 
 + (NSFetchedResultsController *) MR_fetchAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm groupBy:(NSString *)groupingKeyPath delegate:(id<NSFetchedResultsControllerDelegate>)delegate inContext:(NSManagedObjectContext *)context
 {
-	NSFetchedResultsController *controller = [self MR_fetchAllGroupedBy:groupingKeyPath 
-                                                          withPredicate:searchTerm
-                                                               sortedBy:sortTerm 
-                                                              ascending:ascending
-                                                               delegate:delegate
-                                                              inContext:context];
-	
-	[self MR_performFetch:controller];
-	return controller;
+	return [self MR_fetchAllGroupedBy:groupingKeyPath
+			    withPredicate:searchTerm
+				 sortedBy:sortTerm
+				ascending:ascending
+				 delegate:delegate
+				inContext:context];
 }
 
 + (NSFetchedResultsController *) MR_fetchAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm groupBy:(NSString *)groupingKeyPath delegate:(id<NSFetchedResultsControllerDelegate>)delegate


### PR DESCRIPTION
The MR_fetchAllGroupedBy method already performs a fetch. The extra fetch command was causing a double fetch.

Issue: https://github.com/magicalpanda/MagicalRecord/issues/410
