### PR TITLE
iCloud Time Out

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -217,7 +217,7 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
         [self unlock];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            if ([NSPersistentStore MR_defaultPersistentStore] == nil)
+            if ([[self persistentStores] count] && [NSPersistentStore MR_defaultPersistentStore] == nil)
             {
                 [NSPersistentStore MR_setDefaultPersistentStore:[[self persistentStores] objectAtIndex:0]];
             }


### PR DESCRIPTION
Do the same check as in setDefaultStoreCoordinator so it won't crash if no persistent stores exists.

https://github.com/magicalpanda/MagicalRecord/issues/358

After that I check if the persistent store is set and I know that iCloud timed out.
