### PR TITLE
Cleanup when finished

### DIFF
--- a/MagicalRecord/Core/MagicalRecord+Actions.m
+++ b/MagicalRecord/Core/MagicalRecord+Actions.m
@@ -154,9 +154,8 @@
                     errorHandler(error);
                 }
             }
+			[MagicalRecord didEndSaveOperation];
         }];
-		
-		[MagicalRecord didEndSaveOperation];
     }];
 }
 

--- a/MagicalRecord/Core/MagicalRecord+Actions.m
+++ b/MagicalRecord/Core/MagicalRecord+Actions.m
@@ -8,6 +8,12 @@
 #import "CoreData+MagicalRecord.h"
 #import "NSManagedObjectContext+MagicalRecord.h"
 
+@interface MagicalRecord (Internal)
+
++ (void) didBeginSaveOperation;
++ (void) didEndSaveOperation;
+
+@end
 
 @implementation MagicalRecord (Actions)
 
@@ -20,6 +26,8 @@
 
 + (void) saveWithBlock:(void(^)(NSManagedObjectContext *localContext))block completion:(MRSaveCompletionHandler)completion;
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *mainContext  = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextWithParent:mainContext];
 
@@ -29,11 +37,15 @@
         }
 
         [localContext MR_saveWithOptions:MRSaveParentContexts|MRSaveSynchronously completion:completion];
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 
 + (void) saveUsingCurrentThreadContextWithBlock:(void (^)(NSManagedObjectContext *localContext))block completion:(MRSaveCompletionHandler)completion;
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextForCurrentThread];
 
     [localContext performBlock:^{
@@ -42,6 +54,8 @@
         }
 
         [localContext MR_saveWithOptions:MRSaveParentContexts|MRSaveSynchronously completion:completion];
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 
@@ -50,6 +64,8 @@
 
 + (void) saveWithBlockAndWait:(void(^)(NSManagedObjectContext *localContext))block;
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *mainContext  = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextWithParent:mainContext];
 
@@ -59,11 +75,15 @@
         }
 
         [localContext MR_saveWithOptions:MRSaveParentContexts|MRSaveSynchronously completion:nil];
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 
 + (void) saveUsingCurrentThreadContextWithBlockAndWait:(void (^)(NSManagedObjectContext *localContext))block;
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextForCurrentThread];
 
     [localContext performBlockAndWait:^{
@@ -72,6 +92,8 @@
         }
 
         [localContext MR_saveWithOptions:MRSaveParentContexts|MRSaveSynchronously completion:nil];
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 
@@ -88,6 +110,8 @@
 
 + (void) saveInBackgroundWithBlock:(void(^)(NSManagedObjectContext *localContext))block completion:(void(^)(void))completion
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *mainContext  = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextWithParent:mainContext];
 
@@ -103,11 +127,15 @@
         {
             completion();
         }
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 
 + (void) saveInBackgroundUsingCurrentContextWithBlock:(void (^)(NSManagedObjectContext *localContext))block completion:(void (^)(void))completion errorHandler:(void (^)(NSError *error))errorHandler;
 {
+	[MagicalRecord didBeginSaveOperation];
+	
     NSManagedObjectContext *localContext = [NSManagedObjectContext MR_contextForCurrentThread];
 
     [localContext performBlock:^{
@@ -127,6 +155,8 @@
                 }
             }
         }];
+		
+		[MagicalRecord didEndSaveOperation];
     }];
 }
 

--- a/MagicalRecord/Core/MagicalRecord.h
+++ b/MagicalRecord/Core/MagicalRecord.h
@@ -43,6 +43,10 @@ typedef void (^CoreDataBlock)(NSManagedObjectContext *context);
 
 + (NSString *) currentStack;
 
++ (void) cleanUpWhenFinishedSaving;
++ (void) cancelCleanUpWhenFinishedSaving;
++ (BOOL) isWaitingToCleanUp;
+
 + (void) cleanUp;
 
 + (void) setDefaultModelFromClass:(Class)klass;

--- a/MagicalRecord/Core/MagicalRecord.m
+++ b/MagicalRecord/Core/MagicalRecord.m
@@ -5,6 +5,7 @@
 //  Copyright 2010 Magical Panda Software, LLC All rights reserved.
 //
 
+#import <libkern/OSAtomic.h>
 #import "CoreData+MagicalRecord.h"
 
 static volatile int32_t saveOperationsCount;

--- a/MagicalRecord/Core/MagicalRecord.m
+++ b/MagicalRecord/Core/MagicalRecord.m
@@ -7,6 +7,9 @@
 
 #import "CoreData+MagicalRecord.h"
 
+static volatile int32_t saveOperationsCount;
+static BOOL isWaitingToCleanUp;
+
 @interface MagicalRecord (Internal)
 
 + (void) cleanUpStack;
@@ -20,11 +23,49 @@
 
 @end
 
-
 @implementation MagicalRecord
+
++ (void) didBeginSaveOperation
+{
+	OSAtomicIncrement32Barrier(&saveOperationsCount);
+}
+
++ (void) didEndSaveOperation
+{
+	NSUInteger operationsInProgress = OSAtomicDecrement32Barrier(&saveOperationsCount);
+	if (operationsInProgress == 0 && isWaitingToCleanUp) {
+		[self cleanUp];
+	}
+}
+
++ (NSUInteger) countOfSaveOperationsInProgress
+{
+	return OSAtomicAdd32Barrier(0, &saveOperationsCount);
+}
+
++ (void) cleanUpWhenFinishedSaving
+{
+	NSUInteger operationsInProgress = [self countOfSaveOperationsInProgress];
+	if (operationsInProgress == 0) {
+		[self cleanUp];
+	} else {
+		isWaitingToCleanUp = YES;
+	}
+}
+
++ (void) cancelCleanUpWhenFinishedSaving
+{
+	isWaitingToCleanUp = NO;
+}
+
++ (BOOL) isWaitingToCleanUp
+{
+	return isWaitingToCleanUp;
+}
 
 + (void) cleanUp
 {
+	isWaitingToCleanUp = NO;
     [self cleanUpErrorHanding];
     [self cleanUpStack];
 }

--- a/Project Files/Mac Unit Tests/MagicalRecord+ActionsSpec.m
+++ b/Project Files/Mac Unit Tests/MagicalRecord+ActionsSpec.m
@@ -145,6 +145,24 @@ describe(@"MagicalRecord", ^{
             });
         });
 	});
+	
+	context(@"clean up when finished saving", ^{
+		it(@"should clean up immediately when no operations are in progress", ^{
+			[MagicalRecord cleanUpWhenFinishedSaving];
+			[[expectFutureValue([NSPersistentStore MR_defaultPersistentStore]) should] beNil];
+		});
+		
+		it(@"should wait to clean up until all operations are finished", ^{
+			[MagicalRecord saveUsingCurrentThreadContextWithBlockAndWait:^(NSManagedObjectContext *localContext) {
+				[MagicalRecord saveUsingCurrentThreadContextWithBlock:nil
+														   completion:^(BOOL success, NSError *error) {
+					[MagicalRecord cleanUpWhenFinishedSaving];
+					[[expectFutureValue([NSPersistentStore MR_defaultPersistentStore]) should] beNonNil];
+				}];
+			}];
+			[[expectFutureValue([NSPersistentStore MR_defaultPersistentStore]) shouldEventually] beNil];
+		});
+	});
     
     
     // We're testing for deprecated method function — ignore the warnings


### PR DESCRIPTION
This adds functionality to track the count of ongoing performBlock and save operations. This count allows for the ability to perform clean up when the current operations count reaches zero.

This provides a solution for the scenario in which long-running tasks are executing inside of the block being performed on a MOC and we want MagicalRecord to perform a clean up (For example in an application lockdown). Now a cleanUpWhenFinishedSaving method can be called to only tear down the Core Data stack when any ongoing operations have finished.

It is still the application's responsibility to prevent any future operations from being sent to MagicalRecord. However if cleanUpWhenFinishedSaving has been called, cleanUp will be executed when all performBlock and save operations have finished.

*Note* Created pull request against develop branch in response to https://github.com/magicalpanda/MagicalRecord/pull/471