### PR TITLE
Fix typo: depricated -> deprecated

### DIFF
--- a/MagicalRecord/Core/MagicalRecord+ErrorHandling.h
+++ b/MagicalRecord/Core/MagicalRecord+ErrorHandling.h
@@ -10,11 +10,11 @@
 
 @interface MagicalRecord (ErrorHandling)
 
-+ (void) handleErrors:(NSError *)error __attribute__((depricated));
-- (void) handleErrors:(NSError *)error __attribute__((depricated));
++ (void) handleErrors:(NSError *)error __attribute__((deprecated));
+- (void) handleErrors:(NSError *)error __attribute__((deprecated));
 
-+ (void) setErrorHandlerTarget:(id)target action:(SEL)action __attribute__((depricated));
-+ (SEL) errorHandlerAction __attribute__((depricated));
-+ (id) errorHandlerTarget __attribute__((depricated));
++ (void) setErrorHandlerTarget:(id)target action:(SEL)action __attribute__((deprecated));
++ (SEL) errorHandlerAction __attribute__((deprecated));
++ (id) errorHandlerTarget __attribute__((deprecated));
 
 @end


### PR DESCRIPTION
I saw you deprecated some methods in your NSError handling.
I didn't actually try what happens, but you wrote `depricated` instead of `deprecated`.

You could also just use the `DEPRECATED_ATTRIBUTE` macro like so:

``` objc
+ (void) handleErrors:(NSError *)error DEPRECATED_ATTRIBUTE;
```
