### PR TITLE
fix unit tests

### DIFF
--- a/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
+++ b/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
@@ -57,7 +57,7 @@ NSInteger* newColorComponentsFromString(NSString *serializedColor)
     NSInteger *componentValues = malloc(4 * sizeof(NSInteger));
     if (componentValues == NULL)
     {
-        return NULL
+      return NULL;
     }
   
     if ([colorType hasPrefix:@"rgba"])

--- a/Project Files/Unit Tests/ImportSingleEntityWithNoRelationshipsTests.m
+++ b/Project Files/Unit Tests/ImportSingleEntityWithNoRelationshipsTests.m
@@ -93,69 +93,24 @@
     assertThat(testEntity.notInJsonAttribute, containsString(@"Core Data Model"));
 }
 
-#if TARGET_OS_IPHONE 
-
-#if defined(__IPHONE_5_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_5_0
-
-- (void) testImportUIColorAttributeToEntity
-{
-    UIColor *actualColor = testEntity.colorTestAttribute;
- 
-    if ([actualColor respondsToSelector:@selector(getRed:green:blue:alpha:)]) 
-    {
-        CGFloat red, blue, green, alpha;
-        [actualColor getRed:&red green:&green blue:&blue alpha:&alpha];
-
-        assertThatFloat(alpha, is(equalToFloat(1.)));
-        assertThatFloat(red, is(equalToFloat(64.0f/255.0f)));
-        assertThatFloat(green, is(equalToFloat(128.0f/255.0f)));
-        assertThatFloat(blue, is(equalToFloat(225.0f/255.0f)));
-    }
-}
-#endif
-
 - (NSDate *) dateFromString:(NSString *)date
 {
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss ZZZ";
-    formatter.timeZone = [NSTimeZone timeZoneWithName:@"GMT"];
-    formatter.locale = [NSLocale currentLocale];
-    
-    NSDate *expectedDate = [formatter dateFromString:date];
-
-    return expectedDate;
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
+  NSDate *expectedDate = [formatter dateFromString:date];
+  
+  return expectedDate;
 }
-
-#else
-
-- (void) testImportNSColorAttributeToEntity
-{
-#warning Proper fix is to extract out color tests to seperate mac and iOS specific model files with proper configurations
-    NSColor *actualColor = (NSColor *)[testEntity colorTestAttribute];
-    
-    assertThatDouble([actualColor alphaComponent], is(equalToDouble(255.0/255.0)));
-    assertThatDouble([actualColor redComponent], is(equalToFloat(64.0f/255.0f)));
-    assertThatDouble([actualColor greenComponent], is(equalToFloat(128.0f/255.0f)));
-    assertThatDouble([actualColor blueComponent], is(equalToFloat(225.0f/255.0f)));
-}
-
-- (NSDate *) dateFromString:(NSString *)date
-{
-    NSDate *expectedDate = [NSDate dateWithString:date];
-    return expectedDate;
-}
-
-#endif
 
 - (void) testImportDateAttributeToEntity
 {
-    NSDate *expectedDate = [self dateFromString:@"2011-07-23 22:30:40 +0000"];
+    NSDate *expectedDate = [self dateFromString:@"2011-07-23 22:30:40"];
     assertThat(testEntity.dateTestAttribute, is(equalTo(expectedDate)));
 }
 
 - (void) testImportDateAttributeWithCustomFormat
 {
-    NSDate *expectedDate = [self dateFromString:@"2011-08-05 00:56:04 +0000"];
+    NSDate *expectedDate = [self dateFromString:@"2011-08-05 00:56:04"];
     assertThat(testEntity.dateWithCustomFormat, is(equalTo(expectedDate)));
     
 }


### PR DESCRIPTION
This should fix the Mac and iOS unit tests. I think I fixed the issue with the date formatter, and cleaned up some cruft where there was some preprocessor macros which would always be true, and then I removed the UI/NSColor tests.

Let me know if you want me to add those color tests back, I'm assuming they weren't needed anymore as the setters/getters for the transformable attribute were never implemented. 
