### PR TITLE
Fixed cleaning up incompatible stores not working when WAL is being used

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -80,8 +80,14 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
         BOOL isMigrationError = [error code] == NSPersistentStoreIncompatibleVersionHashError || [error code] == NSMigrationMissingSourceModelError;
         if ([[error domain] isEqualToString:NSCocoaErrorDomain] && isMigrationError)
         {
-            // Could not open the database, so... kill it!
+            // Could not open the database, so... kill it! (AND WAL bits)
+            NSString *rawURL = [url absoluteString];
+            NSURL *shmSidecar = [NSURL URLWithString:[rawURL stringByAppendingString:@"-shm"]];
+            NSURL *walSidecar = [NSURL URLWithString:[rawURL stringByAppendingString:@"-wal"]];
             [[NSFileManager defaultManager] removeItemAtURL:url error:nil];
+            [[NSFileManager defaultManager] removeItemAtURL:shmSidecar error:nil];
+            [[NSFileManager defaultManager] removeItemAtURL:walSidecar error:nil];
+            
 
             MRLog(@"Removed incompatible model version: %@", [url lastPathComponent]);
             


### PR DESCRIPTION
Cleaning up an incompatible store didn't work when WAL was enabled. There were 2 sidecar files that weren't removed and caused the next run to crash.

This change deletes the sidecar when it's deleting the main sqlite file.
