### PR TITLE
Added Lexical Sort methods to NSManagedObject+MagicalFinders & NSManagedObject+MagicalRequests

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -16,6 +16,10 @@
 + (NSArray *) MR_findAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 + (NSArray *) MR_findAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) MR_findAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending;
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
 
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -59,6 +59,39 @@
 }
 
 
+// ADDED @shujin 2013-07-11
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context
+{
+	NSFetchRequest *request = [self MR_requestAllSortedLexicallyBy:sortTerm ascending:ascending inContext:context];
+	
+	return [self MR_executeFetchRequest:request inContext:context];
+}
+
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending
+{
+	return [self MR_findAllSortedLexicallyBy:sortTerm
+                                  ascending:ascending
+                                  inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+}
+
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
+{
+	NSFetchRequest *request = [self MR_requestAllSortedLexicallyBy:sortTerm
+                                                        ascending:ascending
+                                                    withPredicate:searchTerm
+                                                        inContext:context];
+	
+	return [self MR_executeFetchRequest:request inContext:context];
+}
+
++ (NSArray *) MR_findAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm
+{
+	return [self MR_findAllSortedLexicallyBy:sortTerm
+                                  ascending:ascending
+                              withPredicate:searchTerm
+                                  inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+}
+
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
 {
 	NSFetchRequest *request = [self MR_createFetchRequestInContext:context];

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.h
@@ -27,6 +27,9 @@
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
-
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending;
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
 
 @end

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -107,7 +107,50 @@
 
 + (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
 {
-	NSFetchRequest *request = [self MR_requestAllInContext:context];
+    return [self MR_requestAllSortedBy:sortTerm ascending:ascending withPredicate:searchTerm inContext:context lexicalSort:NO];
+}
+
++ (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
+{
+	NSFetchRequest *request = [self MR_requestAllSortedBy:sortTerm
+                                                ascending:ascending
+                                            withPredicate:searchTerm 
+                                                inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+	return request;
+}
+
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context
+{
+    return [self MR_requestAllSortedLexicallyBy:sortTerm
+                                     ascending:ascending
+                                 withPredicate:nil
+                                     inContext:context];
+}
+
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending
+{
+	return [self MR_requestAllSortedLexicallyBy:sortTerm
+                                     ascending:ascending
+                                     inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+}
+
+// ADDED @shujin 2013-07-11
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context
+{
+    return [self MR_requestAllSortedBy:sortTerm ascending:ascending withPredicate:searchTerm inContext:context lexicalSort:YES];
+}
+
++ (NSFetchRequest *) MR_requestAllSortedLexicallyBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
+{
+	NSFetchRequest *request = [self MR_requestAllSortedLexicallyBy:sortTerm
+                                                        ascending:ascending
+                                                    withPredicate:searchTerm
+                                                        inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
+	return request;
+}
+
++ (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context lexicalSort:(BOOL)lexicalSort {
+    NSFetchRequest *request = [self MR_requestAllInContext:context];
 	if (searchTerm)
     {
         [request setPredicate:searchTerm];
@@ -120,13 +163,19 @@
     {
         NSArray * sortComponents = [sortKey componentsSeparatedByString:@":"];
         if (sortComponents.count > 1)
-          {
-              NSNumber * customAscending = sortComponents.lastObject;
-              ascending = customAscending.boolValue;
-              sortKey = sortComponents[0];
-          }
-      
-        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        {
+            NSNumber * customAscending = sortComponents.lastObject;
+            ascending = customAscending.boolValue;
+            sortKey = sortComponents[0];
+        }
+        
+        NSSortDescriptor *sortDescriptor;
+        if (lexicalSort) {
+            sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending selector:@selector(localizedStandardCompare:)];
+        } else {
+            sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        }
+        
         [sortDescriptors addObject:sortDescriptor];
     }
     
@@ -134,15 +183,5 @@
     
 	return request;
 }
-
-+ (NSFetchRequest *) MR_requestAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm;
-{
-	NSFetchRequest *request = [self MR_requestAllSortedBy:sortTerm
-                                                ascending:ascending
-                                            withPredicate:searchTerm 
-                                                inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
-	return request;
-}
-
 
 @end


### PR DESCRIPTION
This adds lexical-sort (naturally sorted) methods to the Finders & Fetch Requests.

More often than not I find that I need the findAllSortedBy/fetchrequest to be sorted lexically (for example "Item 1", "Item 2", …, "Item 10" instead of "Item 1", "Item 10", "Item 2",…) which is the current default.

So as not to break compatibility, I've added Lexical versions to all the findAllSortedBy: methods, which I've named findAllSortedLexicallyBy:.

Perhaps it might be useful to others too.