### PR TITLE
When multiply ascending Logic error

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -118,15 +118,16 @@
     NSArray* sortKeys = [sortTerm componentsSeparatedByString:@","];
     for (__strong NSString* sortKey in sortKeys)
     {
+    	BOOL tmpAscending = ascending;
         NSArray * sortComponents = [sortKey componentsSeparatedByString:@":"];
         if (sortComponents.count > 1)
           {
               NSNumber * customAscending = sortComponents.lastObject;
-              ascending = customAscending.boolValue;
+              tmpAscending = customAscending.boolValue;
               sortKey = sortComponents[0];
           }
       
-        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:tmpAscending];
         [sortDescriptors addObject:sortDescriptor];
     }
     


### PR DESCRIPTION
According Doc/Fetching.md  sample:

have the results sorted by multiple properties with difference
attributes - will default to whatever you set it to:

```
    NSArray *peopleSorted = [Person
    MR_findAllSortedBy:@"LastName:NO,FirstName" ascending:YES];

    NSArray *peopleSorted = [Person
    MR_findAllSortedBy:@"LastName,FirstName:YES" ascending:NO];
```

There have same logic error.
