### PR TITLE
Update NSPersistentStoreCoordinator+MagicalRecord.m

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -75,8 +75,10 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
                                                         options:options
                                                           error:&error];
     
-    if (!store && [MagicalRecord shouldDeleteStoreOnModelMismatch])
+    if (!store) 
     {
+        if ([MagicalRecord shouldDeleteStoreOnModelMismatch])
+        {
         BOOL isMigrationError = [error code] == NSPersistentStoreIncompatibleVersionHashError || [error code] == NSMigrationMissingSourceModelError;
         if ([[error domain] isEqualToString:NSCocoaErrorDomain] && isMigrationError)
         {
@@ -103,8 +105,8 @@ NSString * const kMagicalRecordPSCDidCompleteiCloudSetupNotification = @"kMagica
                 error = nil;
             }
         }
-                
-        [MagicalRecord handleErrors:error];
+    }
+    [MagicalRecord handleErrors:error];
     }
     return store;
 }


### PR DESCRIPTION
Reports error if fails to initialise persistant store when shouldDeleteStoreOnModelMismatch is nil.
https://github.com/magicalpanda/MagicalRecord/issues/270#issuecomment-20668863
