### PR TITLE
Fixes the import method never returning a valid array of imported objects

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -271,24 +271,18 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
 + (NSArray *) MR_importFromArray:(NSArray *)listOfObjectData inContext:(NSManagedObjectContext *)context
 {
-    NSMutableArray *objectIDs = [NSMutableArray array];
-    
-    [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) 
-    {    
-        [listOfObjectData enumerateObjectsWithOptions:0 usingBlock:^(id obj, NSUInteger idx, BOOL *stop) 
-        {
-            NSDictionary *objectData = (NSDictionary *)obj;
+    NSMutableArray *dataObjects = [NSMutableArray array];
 
-            NSManagedObject *dataObject = [self MR_importFromObject:objectData inContext:localContext];
+    [listOfObjectData enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop)
+    {
+        NSDictionary *objectData = (NSDictionary *)obj;
 
-            if ([context obtainPermanentIDsForObjects:[NSArray arrayWithObject:dataObject] error:nil])
-            {
-              [objectIDs addObject:[dataObject objectID]];
-            }
-        }];
+        NSManagedObject *dataObject = [self MR_importFromObject:objectData inContext:context];
+
+        [dataObjects addObject:dataObject];
     }];
-    
-    return [self MR_findAllWithPredicate:[NSPredicate predicateWithFormat:@"self IN %@", objectIDs] inContext:context];
+
+    return dataObjects;
 }
 
 @end


### PR DESCRIPTION
Importing data does not save immediately, and acts directly upon the information that is passed. Fixes an error where the imported array of objects was always returned as nil.

This pull request is based upon work done by @badeen in #535.
