### PR TITLE
Added a method to NSManagedObjectModel category to allow creation of a model contained in a separate resource bundle when a main bundle does not exist. (As is the case with XCTest cases)

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectModel+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObjectModel+MagicalRecord.h
@@ -19,5 +19,6 @@
 + (NSManagedObjectModel *) MR_newManagedObjectModelNamed:(NSString *)modelFileName NS_RETURNS_RETAINED;
 + (NSManagedObjectModel *) MR_managedObjectModelNamed:(NSString *)modelFileName;
 + (NSManagedObjectModel *) MR_newModelNamed:(NSString *) modelName inBundleNamed:(NSString *) bundleName NS_RETURNS_RETAINED;
++ (NSManagedObjectModel *) MR_newModelNamed:(NSString *) modelName inBundle:(NSBundle*) bundle NS_RETURNS_RETAINED;
 
 @end

--- a/MagicalRecord/Categories/NSManagedObjectModel+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectModel+MagicalRecord.m
@@ -44,6 +44,17 @@ static NSManagedObjectModel *defaultManagedObjectModel_ = nil;
     return mom;
 }
 
++ (NSManagedObjectModel *) MR_newModelNamed:(NSString *) modelName inBundle:(NSBundle*) bundle
+{
+    NSString *path = [bundle pathForResource:[modelName stringByDeletingPathExtension]
+                                                     ofType:[modelName pathExtension]];
+    NSURL *modelUrl = [NSURL fileURLWithPath:path];
+    
+    NSManagedObjectModel *mom = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelUrl];
+    
+    return mom;
+}
+
 + (NSManagedObjectModel *) MR_newManagedObjectModelNamed:(NSString *)modelFileName
 {
 	NSString *path = [[NSBundle mainBundle] pathForResource:[modelFileName stringByDeletingPathExtension] 


### PR DESCRIPTION
Added a method to NSManagedObjectModel category to allow creation of a model contained in a separate resource bundle when a main bundle does not exist. (As is the case with XCTest cases)
