### PR TITLE
Update defaultLocalStoreUrl to use defaultStoreName

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
@@ -73,7 +73,7 @@ static NSPersistentStore *defaultPersistentStore_ = nil;
 
 + (NSURL *) MR_defaultLocalStoreUrl
 {
-    return [self MR_urlForStoreName:kMagicalRecordDefaultStoreFileName];
+    return [self MR_urlForStoreName:[MagicalRecord defaultStoreName]];
 }
 
 @end

--- a/Project Files/Tests/Core/MagicalRecordTests.m
+++ b/Project Files/Tests/Core/MagicalRecordTests.m
@@ -37,7 +37,7 @@
 
 - (void) testCreateDefaultCoreDataStack
 {
-    NSURL *testStoreURL = [NSPersistentStore urlForStoreName:kMagicalRecordDefaultStoreFileName];
+    NSURL *testStoreURL = [NSPersistentStore MR_defaultLocalStoreUrl];
     [[NSFileManager defaultManager] removeItemAtPath:[testStoreURL path] error:nil];
     
     [MagicalRecord setupCoreDataStack];

--- a/Project Files/Tests/Core/NSPersisentStoreHelperTests.m
+++ b/Project Files/Tests/Core/NSPersisentStoreHelperTests.m
@@ -22,7 +22,7 @@
 - (void) testDefaultStoreFolderForiOSDevicesIsTheApplicationSupportFolder
 {
     NSString *applicationLibraryDirectory = [self applicationStorageDirectory];
-    NSString *defaultStoreName = kMagicalRecordDefaultStoreFileName;
+    NSString *defaultStoreName = [MagicalRecord defaultStoreName];
     
     NSURL *expectedStoreUrl = [NSURL fileURLWithPath:[applicationLibraryDirectory stringByAppendingPathComponent:defaultStoreName]];
     
@@ -74,7 +74,7 @@
 {
     NSString *applictionSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) lastObject];
     NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
-    NSString *defaultStoreName = kMagicalRecordDefaultStoreFileName;
+    NSString *defaultStoreName = [MagicalRecord defaultStoreName];
     
     NSURL *expectedStoreUrl = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@/%@", applictionSupportDirectory, applicationName, defaultStoreName]];
     


### PR DESCRIPTION
`[MagicalRecord setupCoreDataStack]` uses `[MagicalRecord defaultStoreName]`
While the NSPersistentStore category is using the old constant.

For example, when kCFBundleNameKey exists.
`[MagicalRecord setupCoreDataStack]` creates the database at {kCFBundleNameKey}.sqlite
but `[NSPersistentStore MR_defaultLocalStoreUrl]` returns the old fallback file name `CoreDataStore.sqlite`

Some tests are in _Needs porting_, what tests do you prefer?
