### PR TITLE
Added protocols to get rid of Xcode 5 warnings.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -9,6 +9,15 @@
 #import "NSObject+MagicalDataImport.h"
 #import <objc/runtime.h>
 
+@protocol MogeneratorImport <NSObject>
+
+- (BOOL)shouldImport:(id)object;
+- (void)willImport:(id)object;
+- (void)didImport:(id)object;
+- (id)MR_valueForUndefinedKey:(id)object;
+
+@end
+
 void MR_swapMethodsFromClass(Class c, SEL orig, SEL new);
 
 NSString * const kMagicalRecordImportCustomDateFormatKey            = @"dateFormat";

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -5,6 +5,12 @@
 
 #import "CoreData+MagicalRecord.h"
 
+@protocol Mogenerator <NSObject>
+
+- (id)entityInManagedObjectContext:(NSManagedObjectContext *)object;
+- (id)insertInManagedObjectContext:(NSManagedObjectContext *)object;
+@end
+
 static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 
 


### PR DESCRIPTION
Two private protocols were added to remove Xcode 5 'unrecognized
selector' warnings when compiling for iOS 7.
