### PR TITLE
Magical record to directly inherit from rootSavingContext 

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
@@ -31,7 +31,7 @@ static NSString const * kMagicalRecordManagedObjectContextKey = @"MagicalRecord_
 		NSManagedObjectContext *threadContext = [threadDict objectForKey:kMagicalRecordManagedObjectContextKey];
 		if (threadContext == nil)
 		{
-			threadContext = [self MR_contextWithParent:[NSManagedObjectContext MR_defaultContext]];
+			threadContext = [self MR_contextWithParent:[NSManagedObjectContext MR_rootSavingContext]];
 			[threadDict setObject:threadContext forKey:kMagicalRecordManagedObjectContextKey];
 		}
 		return threadContext;


### PR DESCRIPTION
We now prevent magical record from locking up the main thread by accessing it through the default context. This should speed things way up when you use MagicalRecord on other threads.
