### PR TITLE
Changed contexts merging logic from SaveWithBlock methods

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
@@ -72,7 +72,14 @@ NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification = @"kMagica
           self == [NSManagedObjectContext MR_defaultContext] ? @"*** DEFAULT *** " : @"",
           ([NSThread isMainThread] ? @" *** on Main Thread ***" : @""));
     
-	[self mergeChangesFromContextDidSaveNotification:notification];
+    if ((![NSThread isMainThread]) && ([NSManagedObjectContext MR_defaultContext]))
+	{
+        [self MR_mergeChangesOnMainThread:notification];
+    }
+    else
+    {
+        [self mergeChangesFromContextDidSaveNotification:notification];
+    }
 }
 
 - (void) MR_mergeChangesOnMainThread:(NSNotification *)notification;

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -84,13 +84,6 @@ static NSString * const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSM
     defaultManagedObjectContext_ = moc;
     [defaultManagedObjectContext_ MR_setWorkingName:@"DEFAULT"];
     
-    if ((defaultManagedObjectContext_ != nil) && ([self MR_rootSavingContext] != nil)) {
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(rootContextChanged:)
-                                                     name:NSManagedObjectContextDidSaveNotification
-                                                   object:[self MR_rootSavingContext]];
-    }
-    
     [moc MR_obtainPermanentIDsBeforeSaving];
     if ([MagicalRecord isICloudEnabled])
     {
@@ -107,18 +100,6 @@ static NSString * const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSM
                                                                        }];        
     }
     MRLog(@"Set Default Context: %@", defaultManagedObjectContext_);
-}
-
-+ (void)rootContextChanged:(NSNotification *)notification {
-    if ([NSThread isMainThread] == NO) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self rootContextChanged:notification];
-        });
-        
-        return;
-    }
-    
-    [[self MR_defaultContext] mergeChangesFromContextDidSaveNotification:notification];
 }
 
 + (NSManagedObjectContext *) MR_rootSavingContext;


### PR DESCRIPTION
Merge all changes from Root saving Context in default context can cause unwanted behaviours if the changes are initilally generated in default context itself (Default Context -> Root Context -> Default context). 
In many cases - especially on iOS 6 - deleted MO “reappears” in the default context after saving
with MR_saveToPersistantStore methods.
For this reason I’ve removed the observer from the root context and added an observer only for localcontext created in saveWithBlock methods
