### PR TITLE
Use instancetype instead of id for return type in finder methods.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.h
@@ -26,7 +26,7 @@
 + (NSNumber *)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 + (NSNumber *)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
 
-- (id) MR_objectWithMinValueFor:(NSString *)property;
-- (id) MR_objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
+- (instancetype) MR_objectWithMinValueFor:(NSString *)property;
+- (instancetype) MR_objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 
 @end

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.h
@@ -20,8 +20,8 @@ extern NSString * const kMagicalRecordImportRelationshipTypeKey;
 
 - (BOOL) MR_importValuesForKeysWithObject:(id)objectData;
 
-+ (id) MR_importFromObject:(id)data;
-+ (id) MR_importFromObject:(id)data inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_importFromObject:(id)data;
++ (instancetype) MR_importFromObject:(id)data inContext:(NSManagedObjectContext *)context;
 
 + (NSArray *) MR_importFromArray:(NSArray *)listOfObjectData;
 + (NSArray *) MR_importFromArray:(NSArray *)listOfObjectData inContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -20,20 +20,20 @@
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) MR_findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
 
-+ (id) MR_findFirst;
-+ (id) MR_findFirstInContext:(NSManagedObjectContext *)context;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes inContext:(NSManagedObjectContext *)context;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending andRetrieveAttributes:(id)attributes, ...;
-+ (id) MR_findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context andRetrieveAttributes:(id)attributes, ...;
-+ (id) MR_findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue;
-+ (id) MR_findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;
-+ (id) MR_findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending;
-+ (id) MR_findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirst;
++ (instancetype) MR_findFirstInContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending andRetrieveAttributes:(id)attributes, ...;
++ (instancetype) MR_findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context andRetrieveAttributes:(id)attributes, ...;
++ (instancetype) MR_findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue;
++ (instancetype) MR_findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending;
++ (instancetype) MR_findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 
 + (NSArray *) MR_findByAttribute:(NSString *)attribute withValue:(id)searchValue;
 + (NSArray *) MR_findByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -16,8 +16,8 @@
 
 + (NSArray *) MR_executeFetchRequest:(NSFetchRequest *)request;
 + (NSArray *) MR_executeFetchRequest:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
-+ (id) MR_executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request;
-+ (id) MR_executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request;
++ (instancetype) MR_executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 
@@ -29,8 +29,8 @@
 + (NSEntityDescription *) MR_entityDescriptionInContext:(NSManagedObjectContext *)context;
 + (NSArray *) MR_propertiesNamed:(NSArray *)properties;
 
-+ (id) MR_createEntity;
-+ (id) MR_createInContext:(NSManagedObjectContext *)context;
++ (instancetype) MR_createEntity;
++ (instancetype) MR_createInContext:(NSManagedObjectContext *)context;
 - (BOOL) MR_deleteEntity;
 - (BOOL) MR_deleteInContext:(NSManagedObjectContext *)context;
 
@@ -43,8 +43,8 @@
 + (NSArray *) MR_ascendingSortDescriptors:(NSArray *)attributesToSortBy;
 + (NSArray *) MR_descendingSortDescriptors:(NSArray *)attributesToSortBy;
 
-- (id) MR_inContext:(NSManagedObjectContext *)otherContext;
-- (id) MR_inThreadContext;
+- (instancetype) MR_inContext:(NSManagedObjectContext *)otherContext;
+- (instancetype) MR_inThreadContext;
 
 @end
 

--- a/MagicalRecord/Core/MagicalRecordShorthand.h
+++ b/MagicalRecord/Core/MagicalRecordShorthand.h
@@ -19,13 +19,13 @@
 + (BOOL) hasAtLeastOneEntityInContext:(NSManagedObjectContext *)context;
 + (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 + (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
-- (id) objectWithMinValueFor:(NSString *)property;
-- (id) objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
+- (instancetype) objectWithMinValueFor:(NSString *)property;
+- (instancetype) objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 @end
 @interface NSManagedObject (MagicalRecord_DataImportShortHand)
 - (BOOL) importValuesForKeysWithObject:(id)objectData;
-+ (id) importFromObject:(id)data;
-+ (id) importFromObject:(id)data inContext:(NSManagedObjectContext *)context;
++ (instancetype) importFromObject:(id)data;
++ (instancetype) importFromObject:(id)data inContext:(NSManagedObjectContext *)context;
 + (NSArray *) importFromArray:(NSArray *)listOfObjectData;
 + (NSArray *) importFromArray:(NSArray *)listOfObjectData inContext:(NSManagedObjectContext *)context;
 @end
@@ -38,20 +38,20 @@
 + (NSArray *) findAllSortedBy:(NSString *)sortTerm ascending:(BOOL)ascending withPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
 + (NSArray *) findAllWithPredicate:(NSPredicate *)searchTerm;
 + (NSArray *) findAllWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
-+ (id) findFirst;
-+ (id) findFirstInContext:(NSManagedObjectContext *)context;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes inContext:(NSManagedObjectContext *)context;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending andRetrieveAttributes:(id)attributes, ...;
-+ (id) findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context andRetrieveAttributes:(id)attributes, ...;
-+ (id) findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue;
-+ (id) findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;
-+ (id) findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending;
-+ (id) findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirst;
++ (instancetype) findFirstInContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm inContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchterm sortedBy:(NSString *)property ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm andRetrieveAttributes:(NSArray *)attributes inContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending andRetrieveAttributes:(id)attributes, ...;
++ (instancetype) findFirstWithPredicate:(NSPredicate *)searchTerm sortedBy:(NSString *)sortBy ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context andRetrieveAttributes:(id)attributes, ...;
++ (instancetype) findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue;
++ (instancetype) findFirstByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;
++ (instancetype) findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending;
++ (instancetype) findFirstOrderedByAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 + (NSArray *) findByAttribute:(NSString *)attribute withValue:(id)searchValue;
 + (NSArray *) findByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;
 + (NSArray *) findByAttribute:(NSString *)attribute withValue:(id)searchValue andOrderBy:(NSString *)sortTerm ascending:(BOOL)ascending;
@@ -72,16 +72,16 @@
 + (void) setDefaultBatchSize:(NSUInteger)newBatchSize;
 + (NSArray *) executeFetchRequest:(NSFetchRequest *)request;
 + (NSArray *) executeFetchRequest:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
-+ (id) executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request;
-+ (id) executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
++ (instancetype) executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request;
++ (instancetype) executeFetchRequestAndReturnFirstObject:(NSFetchRequest *)request inContext:(NSManagedObjectContext *)context;
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 + (void) performFetch:(NSFetchedResultsController *)controller;
 #endif
 + (NSEntityDescription *) entityDescription;
 + (NSEntityDescription *) entityDescriptionInContext:(NSManagedObjectContext *)context;
 + (NSArray *) propertiesNamed:(NSArray *)properties;
-+ (id) createEntity;
-+ (id) createInContext:(NSManagedObjectContext *)context;
++ (instancetype) createEntity;
++ (instancetype) createInContext:(NSManagedObjectContext *)context;
 - (BOOL) deleteEntity;
 - (BOOL) deleteInContext:(NSManagedObjectContext *)context;
 + (BOOL) deleteAllMatchingPredicate:(NSPredicate *)predicate;
@@ -90,8 +90,8 @@
 + (BOOL) truncateAllInContext:(NSManagedObjectContext *)context;
 + (NSArray *) ascendingSortDescriptors:(NSArray *)attributesToSortBy;
 + (NSArray *) descendingSortDescriptors:(NSArray *)attributesToSortBy;
-- (id) inContext:(NSManagedObjectContext *)otherContext;
-- (id) inThreadContext;
+- (instancetype) inContext:(NSManagedObjectContext *)otherContext;
+- (instancetype) inThreadContext;
 @end
 @interface NSManagedObject (MagicalRequestsShortHand)
 + (NSFetchRequest *) createFetchRequest;


### PR DESCRIPTION
Changed return type of the finder methods from id to instancetype so that individual model methods can be invoked directly.
