### PR TITLE
[WIP] Add support for aggregate operations grouped by an attribute

### DIFF
--- a/Docs/Fetching.md
+++ b/Docs/Fetching.md
@@ -76,8 +76,9 @@ There are also counterpart methods which return NSUInteger rather than NSNumbers
 #### Aggregate Operations
 
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"diaryEntry.date == %@", today];
-    int totalFat = [[CTFoodDiaryEntry MR_aggregateOperation:@"sum:" onAttribute:@"fatColories" withPredicate:predicate] intValue];
-    int fattest  = [[CTFoodDiaryEntry MR_aggregateOperation:@"max:" onAttribute:@"fatColories" withPredicate:predicate] intValue];
+    NSInteger totalFat = [[CTFoodDiaryEntry MR_aggregateOperation:@"sum:" onAttribute:@"fatCalories" withPredicate:predicate] integerValue];
+    NSInteger fattest  = [[CTFoodDiaryEntry MR_aggregateOperation:@"max:" onAttribute:@"fatCalories" withPredicate:predicate] integerValue];
+    NSArray *caloriesByMonth = [CTFoodDiaryEntry aggregateOperation:@"sum:" onAttribute:@"fatCalories" withPredicate:predicate groupBy:@"month"];
     
 #### Finding from a different context
 

--- a/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
@@ -61,7 +61,7 @@ NSUInteger const kMagicalRecordImportMaximumAttributeFailoverDepth = 10;
     
     NSString               *primaryKeyName      = [relationshipInfo MR_primaryKey];
     NSAttributeDescription *primaryKeyAttribute = [destinationEntity MR_attributeDescriptionForName:primaryKeyName];
-    NSString               *lookupKey           = [[primaryKeyAttribute userInfo] valueForKey:kMagicalRecordImportAttributeKeyMapKey] ? :[primaryKeyAttribute name];
+    NSString               *lookupKey           = [self MR_lookupKeyForAttribute:primaryKeyAttribute] ?: [primaryKeyAttribute name];
 
     return lookupKey;
 }

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.h
@@ -26,6 +26,9 @@
 + (NSNumber *)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 + (NSNumber *)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
 
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath inContext:(NSManagedObjectContext *)context;
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath;
+
 - (instancetype) MR_objectWithMinValueFor:(NSString *)property;
 - (instancetype) MR_objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
@@ -138,4 +138,31 @@
                              inContext:[NSManagedObjectContext MR_defaultContext]];    
 }
 
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath inContext:(NSManagedObjectContext *)context
+{
+    NSExpression *ex = [NSExpression expressionForFunction:function arguments:[NSArray arrayWithObject:[NSExpression expressionForKeyPath:attributeName]]];
+
+    NSExpressionDescription *ed = [[NSExpressionDescription alloc] init];
+    [ed setName:@"result"];
+    [ed setExpression:ex];
+
+    // determine the type of attribute, required to set the expression return type
+    NSAttributeDescription *attributeDescription = [[[self MR_entityDescription] attributesByName] objectForKey:attributeName];
+    [ed setExpressionResultType:[attributeDescription attributeType]];
+    NSArray *properties = [NSArray arrayWithObjects:groupingKeyPath, ed, nil];
+
+    NSFetchRequest *request = [self MR_requestAllWithPredicate:predicate inContext:context];
+    [request setPropertiesToFetch:properties];
+    [request setResultType:NSDictionaryResultType];
+    [request setPropertiesToGroupBy:[NSArray arrayWithObject:groupingKeyPath]];
+
+    NSArray *results = [self MR_executeFetchRequest:request inContext:context];
+    return results;
+}
+
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath
+{
+    return [self MR_aggregateOperation:function onAttribute:attributeName withPredicate:predicate groupBy:groupingKeyPath inContext:[NSManagedObjectContext MR_defaultContext]];
+}
+
 @end

--- a/MagicalRecord/Core/MagicalRecordShorthand.h
+++ b/MagicalRecord/Core/MagicalRecordShorthand.h
@@ -19,6 +19,8 @@
 + (BOOL) hasAtLeastOneEntityInContext:(NSManagedObjectContext *)context;
 + (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 + (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath inContext:(NSManagedObjectContext *)context;
++ (NSArray *) MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString*)groupingKeyPath;
 - (instancetype) objectWithMinValueFor:(NSString *)property;
 - (instancetype) objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 @end

--- a/MagicalRecord/MagicalRecordVersion.h
+++ b/MagicalRecord/MagicalRecordVersion.h
@@ -1,5 +1,5 @@
 // Do not edit
-#define MAGICAL_RECORD_DISPLAY_VERSION @"2.2develop"
-#define MAGICAL_RECORD_VERSION 595
-#define MAGICAL_RECORD_BUILD @"1a09221"
-// Updated on Wed Jan 1 12:39:31 EST 2014
+#define MAGICAL_RECORD_DISPLAY_VERSION @"2.2feature/fix-nspersistentstorecoordinator-error-handling"
+#define MAGICAL_RECORD_VERSION 603
+#define MAGICAL_RECORD_BUILD @"0db8a44"
+// Updated on Wed Jan 1 14:06:07 EST 2014


### PR DESCRIPTION
Allows queries like:

``` objective-c
NSArray* caloriesByMonth = [CTFoodDiaryEntry aggregateOperation:@"sum:" onAttribute:@"fatCalories" withPredicate:predicate groupBy:@"month"];
```

This supersedes #113 and #457, and requires tests before it can be merged.
- [ ] Add tests
