### PR TITLE
Add method to delete managed objects in a container object that conforms to NSFastEnumeration

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
@@ -28,4 +28,6 @@ extern NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification;
 - (void) MR_setWorkingName:(NSString *)workingName;
 - (NSString *) MR_workingName;
 
+- (void) MR_deleteObjects:(id <NSFastEnumeration>)managedObjects;
+
 @end

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -249,5 +249,12 @@ static NSString * const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSM
     return workingName;
 }
 
+- (void) MR_deleteObjects:(id <NSFastEnumeration>)managedObjects
+{
+    for (NSManagedObject *managedObject in managedObjects)
+    {
+        [self deleteObject:managedObject];
+    }
+}
 
 @end

--- a/MagicalRecord/Core/MagicalRecordShorthand.h
+++ b/MagicalRecord/Core/MagicalRecordShorthand.h
@@ -125,6 +125,7 @@
 - (NSString *) parentChain;
 - (void) setWorkingName:(NSString *)workingName;
 - (NSString *) workingName;
+- (void) MR_deleteObjects:(id <NSFastEnumeration>)managedObjects;
 @end
 @interface NSManagedObjectContext (MagicalSavesShortHand)
 - (void) saveOnlySelfWithCompletion:(MRSaveCompletionHandler)completion;


### PR DESCRIPTION
This is a clean up of the PR submitted by @ryanmaxwell in #328. I've altered the name of the method to more closely match NSManagedObjectContext's existing `deleteObject:` method, and allow passing in any object that conforms to `NSFastEnumeration`.

Closes #328.
