### PR TITLE
Potential fix to issue #644

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -42,9 +42,6 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         [invocation setSelector:selector];
         [invocation setArgument:&value atIndex:2];
         [invocation invoke];
-        // import callbacks must return a BOOL indicating whether they have 
-        // handled the import themselves (YES) or whether MR still needs to handle it (NO).
-        // the default is YES for backwards compatibility.
         BOOL returnValue = YES;
         [invocation getReturnValue:&returnValue];
         return returnValue;


### PR DESCRIPTION
import callbacks must return a BOOL indicating whether they have handled the import themselves (YES) or whether MR still needs to handle it (NO). the default is YES for backwards compatibility.
