### PR TITLE
Update NSManagedObject+MagicalDataImport.m

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -286,6 +286,12 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
     
     id value = [objectData MR_valueForAttribute:primaryAttribute];
     
+    // Convert Number to String if the classes don't match
+    if ([[primaryAttribute attributeValueClassName] isKindOfClass:[NSString class]] &&
+        [value isKindOfClass:[NSNumber class]]) {
+        value = [value description];
+    }
+    
     NSManagedObject *managedObject = [self MR_findFirstByAttribute:[primaryAttribute name] withValue:value inContext:context];
     if (managedObject == nil) 
     {


### PR DESCRIPTION
If the primary attribute is `NSString` but we are receiving `NSNumber` the `NSPredicate` does not always convert it properly, so we will not get our existing object from a DB and the new duplicate will be created.

This patch fixes such weird issue.
