### PR TITLE
Fixes `colorTestAttribute`'s attribute value class on `SingleEntityWithNoRelationships`

### DIFF
--- a/Tests/Fixtures/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
+++ b/Tests/Fixtures/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
@@ -70,7 +70,7 @@
         <attribute name="booleanTestAttribute" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="colorTestAttribute" optional="YES" attributeType="Transformable" syncable="YES">
             <userInfo>
-                <entry key="attributeValueClassName" value="*Color"/>
+                <entry key="attributeValueClassName" value="UIColor"/>
             </userInfo>
         </attribute>
         <attribute name="dateTestAttribute" optional="YES" attributeType="Date" syncable="YES"/>

--- a/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.h
+++ b/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.h
@@ -35,7 +35,7 @@ extern const struct SingleEntityWithNoRelationshipsAttributes {
 
 
 
-@class NSObject;
+@class UIColor;
 
 
 
@@ -92,7 +92,7 @@ extern const struct SingleEntityWithNoRelationshipsAttributes {
 
 
 
-@property (nonatomic, strong) id colorTestAttribute;
+@property (nonatomic, strong) UIColor* colorTestAttribute;
 
 
 
@@ -285,8 +285,8 @@ extern const struct SingleEntityWithNoRelationshipsAttributes {
 
 
 
-- (id)primitiveColorTestAttribute;
-- (void)setPrimitiveColorTestAttribute:(id)value;
+- (UIColor*)primitiveColorTestAttribute;
+- (void)setPrimitiveColorTestAttribute:(UIColor*)value;
 
 
 


### PR DESCRIPTION
Fixes `colorTestAttribute`'s attribute value class on `SingleEntityWithNoRelationships`  so Mogenerator will correctly generate this entity when testing.

All tests pass after change.
