### PR TITLE
Added support for boolean attribute provided as a string in data source

### DIFF
--- a/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
@@ -50,6 +50,11 @@
                 value = numberFromString([value description]);
             }
         }
+        else if (attributeType == NSBooleanAttributeType) {
+            if (![value isKindOfClass:[NSNumber class]] && value != [NSNull null]) {
+            value = [NSNumber numberWithBool:[value boolValue]];
+            }
+        }
         else if (attributeType == NSStringAttributeType) {
             if (![value isKindOfClass:[NSString class]] && value != [NSNull null]) {
                 value = [value description];

--- a/Tests/DataImport/ImportSingleEntityWithNoRelationshipsTests.m
+++ b/Tests/DataImport/ImportSingleEntityWithNoRelationshipsTests.m
@@ -99,6 +99,11 @@
     XCTAssertEqualObjects(testEntity.numberAsStringTestAttribute, @"10248909829", @"numberAsStringTestAttribute did not contain expected value, instead found: %@", testEntity.numberAsStringTestAttribute);
 }
 
+- (void)testImportBooleanAsStringAttributeToEntity
+{
+    XCTAssertTrue(testEntity.booleanAsStringTestAttribute, @"booleanFromStringTestAttribute did not contain expected value, instead found: %@", testEntity.booleanAsStringTestAttribute);
+}
+
 - (void)testImportAttributeNotInJsonData
 {
     NSRange rangeOfString = [testEntity.notInJsonAttribute rangeOfString:@"Core Data Model"];

--- a/Tests/Fixtures/SingleEntityWithNoRelationships.json
+++ b/Tests/Fixtures/SingleEntityWithNoRelationships.json
@@ -19,4 +19,5 @@
     "doubleAsStringTestAttribute": "124.3",
     "floatAsStringTestAttribute": "10000000000",
     "numberAsStringTestAttribute" : 10248909829,
+    "booleanAsStringTestAttribute": "true",
 }

--- a/Tests/Fixtures/SingleEntityWithNoRelationships.plist
+++ b/Tests/Fixtures/SingleEntityWithNoRelationships.plist
@@ -30,5 +30,7 @@
 	<string>8/5/2011 1-56-04 AM</string>
 	<key>nullTestAttribte</key>
 	<string></string>
+    <key>booleanAsStringTestAttribute</key>
+	<string>true</string>
 </dict>
 </plist>

--- a/Tests/Fixtures/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
+++ b/Tests/Fixtures/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
@@ -67,6 +67,7 @@
         </relationship>
     </entity>
     <entity name="SingleEntityWithNoRelationships" representedClassName="SingleEntityWithNoRelationships" syncable="YES">
+        <attribute name="booleanAsStringTestAttribute" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="booleanTestAttribute" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="colorTestAttribute" optional="YES" attributeType="Transformable" syncable="YES">
             <userInfo>

--- a/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.h
+++ b/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.h
@@ -6,6 +6,7 @@
 
 
 extern const struct SingleEntityWithNoRelationshipsAttributes {
+	__unsafe_unretained NSString *booleanAsStringTestAttribute;
 	__unsafe_unretained NSString *booleanTestAttribute;
 	__unsafe_unretained NSString *colorTestAttribute;
 	__unsafe_unretained NSString *dateTestAttribute;
@@ -71,6 +72,22 @@ extern const struct SingleEntityWithNoRelationshipsAttributes {
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
 - (SingleEntityWithNoRelationshipsID*)objectID;
+
+
+
+
+
+@property (nonatomic, strong) NSNumber* booleanAsStringTestAttribute;
+
+
+
+
+@property (atomic) BOOL booleanAsStringTestAttributeValue;
+- (BOOL)booleanAsStringTestAttributeValue;
+- (void)setBooleanAsStringTestAttributeValue:(BOOL)value_;
+
+
+//- (BOOL)validateBooleanAsStringTestAttribute:(id*)value_ error:(NSError**)error_;
 
 
 
@@ -274,6 +291,15 @@ extern const struct SingleEntityWithNoRelationshipsAttributes {
 
 
 @interface _SingleEntityWithNoRelationships (CoreDataGeneratedPrimitiveAccessors)
+
+
+- (NSNumber*)primitiveBooleanAsStringTestAttribute;
+- (void)setPrimitiveBooleanAsStringTestAttribute:(NSNumber*)value;
+
+- (BOOL)primitiveBooleanAsStringTestAttributeValue;
+- (void)setPrimitiveBooleanAsStringTestAttributeValue:(BOOL)value_;
+
+
 
 
 - (NSNumber*)primitiveBooleanTestAttribute;

--- a/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.m
+++ b/Tests/Fixtures/TestModel/_SingleEntityWithNoRelationships.m
@@ -5,6 +5,7 @@
 
 
 const struct SingleEntityWithNoRelationshipsAttributes SingleEntityWithNoRelationshipsAttributes = {
+	.booleanAsStringTestAttribute = @"booleanAsStringTestAttribute",
 	.booleanTestAttribute = @"booleanTestAttribute",
 	.colorTestAttribute = @"colorTestAttribute",
 	.dateTestAttribute = @"dateTestAttribute",
@@ -55,6 +56,11 @@ const struct SingleEntityWithNoRelationshipsAttributes SingleEntityWithNoRelatio
 + (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
 	
+	if ([key isEqualToString:@"booleanAsStringTestAttributeValue"]) {
+		NSSet *affectingKey = [NSSet setWithObject:@"booleanAsStringTestAttribute"];
+		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
+	}
 	if ([key isEqualToString:@"booleanTestAttributeValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"booleanTestAttribute"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
@@ -93,6 +99,34 @@ const struct SingleEntityWithNoRelationshipsAttributes SingleEntityWithNoRelatio
 
 	return keyPaths;
 }
+
+
+
+
+@dynamic booleanAsStringTestAttribute;
+
+
+
+- (BOOL)booleanAsStringTestAttributeValue {
+	NSNumber *result = [self booleanAsStringTestAttribute];
+	return [result boolValue];
+}
+
+
+- (void)setBooleanAsStringTestAttributeValue:(BOOL)value_ {
+	[self setBooleanAsStringTestAttribute:@(value_)];
+}
+
+
+- (BOOL)primitiveBooleanAsStringTestAttributeValue {
+	NSNumber *result = [self primitiveBooleanAsStringTestAttribute];
+	return [result boolValue];
+}
+
+- (void)setPrimitiveBooleanAsStringTestAttributeValue:(BOOL)value_ {
+	[self setPrimitiveBooleanAsStringTestAttribute:@(value_)];
+}
+
 
 
 


### PR DESCRIPTION
Added support for `booleanAsStringTestAttribute`. That is, where the desired attribute type is `NSBooleanAttributeType` yet the data source is a string value. 

(This may not be commonly encountered with `JSON`-formatted data sources, but it's very possible if the format is `XML` or `PLIST`).

On the current, latest `develop` commit, this event typically (and in my experience, _always_) results in the app crashing during `MagicalRecord` importing.

Also added a test for the new behavior.
All tests passing.
