### PR TITLE
Fixed data import on wrong object class for related objects

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -268,7 +268,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
             if (relatedByAttribute)
             {
 				
-                if (![weakself MR_importValue:localObjectData forKey:relatedByAttribute])
+                if (![relatedObject MR_importValue:localObjectData forKey:relatedByAttribute])
                 {
                     [relatedObject setValue:localObjectData forKey:relatedByAttribute];
                 }


### PR DESCRIPTION
Fixed issue where import value was being called on the wrong object.  Data is for the related object but was asking the local object class to import the info.  The expected result is that the related object ask its own class how to import a value.
