### PR TITLE
Added MR_ prefix to MagicalImportFunctions 

### DIFF
--- a/MagicalRecord/Categories/DataImport/MagicalImportFunctions.h
+++ b/MagicalRecord/Categories/DataImport/MagicalImportFunctions.h
@@ -9,20 +9,20 @@
 #import <Foundation/Foundation.h>
 
 
-NSDate * adjustDateForDST(NSDate *date);
-NSDate * dateFromString(NSString *value, NSString *format);
-NSDate * dateFromNumber(NSNumber *value, BOOL milliseconds);
-NSNumber * numberFromString(NSString *value);
-NSString * attributeNameFromString(NSString *value);
-NSString * primaryKeyNameFromString(NSString *value);
+NSDate * MR_adjustDateForDST(NSDate *date);
+NSDate * MR_dateFromString(NSString *value, NSString *format);
+NSDate * MR_dateFromNumber(NSNumber *value, BOOL milliseconds);
+NSNumber * MR_numberFromString(NSString *value);
+NSString * MR_attributeNameFromString(NSString *value);
+NSString * MR_primaryKeyNameFromString(NSString *value);
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-UIColor * UIColorFromString(NSString *serializedColor);
+UIColor * MR_UIColorFromString(NSString *serializedColor);
 
 #else
 #import <AppKit/AppKit.h>
-NSColor * NSColorFromString(NSString *serializedColor);
+NSColor * MR_NSColorFromString(NSString *serializedColor);
 
 #endif
 extern id (*colorFromString)(NSString *);

--- a/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
+++ b/MagicalRecord/Categories/DataImport/MagicalImportFunctions.m
@@ -11,19 +11,19 @@
 
 #pragma mark - Data import helper functions
 
-NSString * attributeNameFromString(NSString *value)
+NSString * MR_attributeNameFromString(NSString *value)
 {
     NSString *firstCharacter = [[value substringToIndex:1] capitalizedString];
     return [firstCharacter stringByAppendingString:[value substringFromIndex:1]];
 }
 
-NSString * primaryKeyNameFromString(NSString *value)
+NSString * MR_primaryKeyNameFromString(NSString *value)
 {
     NSString *firstCharacter = [[value substringToIndex:1] lowercaseString];
     return [firstCharacter stringByAppendingFormat:@"%@ID", [value substringFromIndex:1]];
 }
 
-NSDate * adjustDateForDST(NSDate *date)
+NSDate * MR_adjustDateForDST(NSDate *date)
 {
     NSTimeInterval dstOffset = [[NSTimeZone localTimeZone] daylightSavingTimeOffsetForDate:date];
     NSDate *actualDate = [date dateByAddingTimeInterval:dstOffset];
@@ -31,7 +31,7 @@ NSDate * adjustDateForDST(NSDate *date)
     return actualDate;
 }
 
-NSDate * dateFromString(NSString *value, NSString *format)
+NSDate * MR_dateFromString(NSString *value, NSString *format)
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
@@ -43,7 +43,7 @@ NSDate * dateFromString(NSString *value, NSString *format)
     return parsedDate;
 }
 
-NSDate * dateFromNumber(NSNumber *value, BOOL milliseconds)
+NSDate * MR_dateFromNumber(NSNumber *value, BOOL milliseconds)
 {
     NSTimeInterval timeInterval = [value doubleValue];
     if (milliseconds) {
@@ -52,7 +52,7 @@ NSDate * dateFromNumber(NSNumber *value, BOOL milliseconds)
     return [NSDate dateWithTimeIntervalSince1970:timeInterval];
 }
 
-NSNumber * numberFromString(NSString *value) {
+NSNumber * MR_numberFromString(NSString *value) {
     return [NSNumber numberWithDouble:[value doubleValue]];
 }
 
@@ -88,7 +88,7 @@ NSInteger* newColorComponentsFromString(NSString *serializedColor)
 
 #if TARGET_OS_IPHONE
 
-UIColor * UIColorFromString(NSString *serializedColor)
+UIColor * MR_UIColorFromString(NSString *serializedColor)
 {
     NSInteger *componentValues = newColorComponentsFromString(serializedColor);
     if (componentValues == NULL)
@@ -104,7 +104,7 @@ UIColor * UIColorFromString(NSString *serializedColor)
     free(componentValues);
     return color;
 }
-id (*colorFromString)(NSString *) = UIColorFromString;
+id (*colorFromString)(NSString *) = MR_UIColorFromString;
 
 #else
 

--- a/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
@@ -38,10 +38,10 @@
             {
                 NSString *dateFormat = [[self userInfo] valueForKey:kMagicalRecordImportCustomDateFormatKey];
                 if ([value isKindOfClass:[NSNumber class]]) {
-                    value = dateFromNumber(value, [dateFormat isEqualToString:kMagicalRecordImportUnixDate13String]);
+                    value = MR_dateFromNumber(value, [dateFormat isEqualToString:kMagicalRecordImportUnixDate13String]);
                 }
                 else {
-                    value = dateFromString([value description], dateFormat ?: kMagicalRecordImportDefaultDateFormatString);
+                    value = MR_dateFromString([value description], dateFormat ?: kMagicalRecordImportDefaultDateFormatString);
                 }
             }
         }
@@ -52,7 +52,7 @@
                  attributeType == NSDoubleAttributeType ||
                  attributeType == NSFloatAttributeType) {
             if (![value isKindOfClass:[NSNumber class]] && value != [NSNull null]) {
-                value = numberFromString([value description]);
+                value = MR_numberFromString([value description]);
             }
         }
         else if (attributeType == NSBooleanAttributeType) {

--- a/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
@@ -13,7 +13,7 @@
 
 - (NSAttributeDescription *) MR_primaryAttributeToRelateBy;
 {
-    NSString *lookupKey = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: primaryKeyNameFromString([self name]);
+    NSString *lookupKey = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([self name]);
 
     return [self MR_attributeDescriptionForName:lookupKey];
 }

--- a/MagicalRecord/Categories/DataImport/NSRelationshipDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSRelationshipDescription+MagicalDataImport.m
@@ -16,7 +16,7 @@
 - (NSString *) MR_primaryKey;
 {
     NSString *primaryKeyName = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: 
-    primaryKeyNameFromString([[self destinationEntity] name]);
+    MR_primaryKeyNameFromString([[self destinationEntity] name]);
     
     return primaryKeyName;
 }

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -264,7 +264,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         
         if ((localObjectData) && (![localObjectData isKindOfClass:[NSDictionary class]]))
         {
-			NSString * relatedByAttribute = [[relationshipInfo userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: primaryKeyNameFromString([[relationshipInfo destinationEntity] name]);
+			NSString * relatedByAttribute = [[relationshipInfo userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([[relationshipInfo destinationEntity] name]);
 			
             if (relatedByAttribute)
             {

--- a/MagicalRecord/MagicalRecordVersion.h
+++ b/MagicalRecord/MagicalRecordVersion.h
@@ -1,5 +1,5 @@
 // Do not edit
 #define MAGICAL_RECORD_DISPLAY_VERSION @"2.2develop"
-#define MAGICAL_RECORD_VERSION 595
-#define MAGICAL_RECORD_BUILD @"1a09221"
-// Updated on Wed Jan 1 12:39:31 EST 2014
+#define MAGICAL_RECORD_VERSION 619
+#define MAGICAL_RECORD_BUILD @"81f27a0"
+// Updated on Thu Apr 3 13:22:06 CEST 2014


### PR DESCRIPTION
Added `MR_` prefix to `MagicalImportFunctions` so that common methods like `dateFromString` don't cause duplicated symbol collisions in apps.
