### PR TITLE
Fixed relationship data import key lookup

### DIFF
--- a/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
@@ -61,7 +61,7 @@ NSUInteger const kMagicalRecordImportMaximumAttributeFailoverDepth = 10;
     
     NSString               *primaryKeyName      = [relationshipInfo MR_primaryKey];
     NSAttributeDescription *primaryKeyAttribute = [destinationEntity MR_attributeDescriptionForName:primaryKeyName];
-    NSString               *lookupKey           = [[primaryKeyAttribute userInfo] valueForKey:kMagicalRecordImportAttributeKeyMapKey] ? :[primaryKeyAttribute name];
+    NSString               *lookupKey           = [self MR_lookupKeyForAttribute:primaryKeyAttribute] ?: [primaryKeyAttribute name];
 
     return lookupKey;
 }


### PR DESCRIPTION
Fixed an issue where if you have more than one mappedKeyName it would not search through all of the mappedKeyNames to find the correct key for the lookup for a relationship object thus causing a duplicate item to be created in the database.  The current implementation takes the first key and assumes it is the correct key.  The expected workflow is to check the first key mappedKeyName then if there is no value for that key to move onto the next key mappedKeyName.1 until either a value is found or all mappedKeyNames have gone through.
