### PR TITLE
MR_clearContextForCurrentThread was not clearing Context Cache Version

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
@@ -63,6 +63,7 @@ static volatile int32_t contextsCacheVersion = 0;
 
 + (void) MR_clearContextForCurrentThread {
     [[[NSThread currentThread] threadDictionary] removeObjectForKey:kMagicalRecordManagedObjectContextKey];
+    [[[NSThread currentThread] threadDictionary] removeObjectForKey:kMagicalRecordManagedObjectContextCacheVersionKey];
 }
 
 @end


### PR DESCRIPTION
MR_clearContextForCurrentThread was not clearing Context Cache Version which would cause an assertion failure on the next call to MR_contextForCurrentThread

Fixes #728
