### PR TITLE
Add CocoaPods to Installation instructions

### DIFF
--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -9,6 +9,16 @@
 	#define MR_SHORTHAND
 	#import "CoreData+MagicalRecord.h"
 
+### CocoaPods
+Alternatively, **MagicalRecord** is available on [CocoaPods](http://cocoapods.org):
+```
+pod 'MagicalRecord'
+```
+Or if you'd prefer to use the category methods without a prefix:
+
+```
+pod 'MagicalRecord/Shorthand'
+```
 
 # Requirements
 


### PR DESCRIPTION
I didn’t find any proper documentation of the Shorthand podspec, only found it as an answer to an issue about `#define MR_SHORTHAND` not working. So I added that too.
