### PR TITLE
Importing <Foundation/Foundation.h>, Swift projects don't include it by default

### DIFF
--- a/MagicalRecord/CoreData+MagicalRecord.h
+++ b/MagicalRecord/CoreData+MagicalRecord.h
@@ -1,10 +1,6 @@
-
-#ifndef NS_BLOCKS_AVAILABLE
-    #warning MagicalRecord requires blocks
-#endif
-
 #ifdef __OBJC__
 
+	#import <Foundation/Foundation.h>
     #import <CoreFoundation/CoreFoundation.h>
     #import <CoreData/CoreData.h>
 
@@ -42,6 +38,10 @@
     #import "NSRelationshipDescription+MagicalDataImport.h"
     #import "NSEntityDescription+MagicalDataImport.h"
 
+#endif
+
+#ifndef NS_BLOCKS_AVAILABLE
+    #warning MagicalRecord requires blocks
 #endif
 
 // @see https://github.com/ccgus/fmdb/commit/aef763eeb64e6fa654e7d121f1df4c16a98d9f4f


### PR DESCRIPTION
Re #786. NS_BLOCKS_AVAILABLE is defined in &lt;Foundation/NSObjCRuntime.h&gt; which is included by &lt;Foundation/Foundation.h&gt;.
