### PR TITLE
Updated sortDescriptor to support localizedCaseInsensitiveCompare:

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -147,7 +147,7 @@
               sortKey = sortComponents[0];
           }
       
-        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending];
+        NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending selector:@selector(localizedCaseInsensitiveCompare:)];
         [sortDescriptors addObject:sortDescriptor];
     }
     


### PR DESCRIPTION
sortKey: "firstName"
value to observe: "b2"
Section header: 'N'

Old code Results:

'B'
Cameroon
'C'
Steve
'S'
b2

New Code Results: 

'B'
b2
'C'
Cameroon
'S'
Steve