### PR TITLE
fix coding conventions

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRequests.m
@@ -13,7 +13,7 @@
 @implementation NSManagedObject (MagicalRequests)
 
 
-+ (NSFetchRequest *)MR_createFetchRequestInContext:(NSManagedObjectContext *)context
++ (NSFetchRequest *) MR_createFetchRequestInContext:(NSManagedObjectContext *)context
 {
 	NSFetchRequest *request = [[NSFetchRequest alloc] init];
 	[request setEntity:[self MR_entityDescriptionInContext:context]];

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -176,7 +176,7 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
     }
 }
 
-+ (void)rootContextChanged:(NSNotification *)notification
++ (void) rootContextChanged:(NSNotification *)notification
 {
     if ([NSThread isMainThread] == NO) {
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
@@ -18,7 +18,7 @@ static volatile int32_t contextsCacheVersion = 0;
 
 @implementation NSManagedObjectContext (MagicalThreading)
 
-+ (void)MR_resetContextForCurrentThread
++ (void) MR_resetContextForCurrentThread
 {
     [[NSManagedObjectContext MR_contextForCurrentThread] reset];
 }

--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
@@ -30,12 +30,12 @@ static NSPersistentStore *defaultPersistentStore_ = nil;
     return [NSSearchPathForDirectoriesInDomains(type, NSUserDomainMask, YES) lastObject];
 }
 
-+ (NSString *)MR_applicationDocumentsDirectory 
++ (NSString *) MR_applicationDocumentsDirectory
 {
 	return [self MR_directory:NSDocumentDirectory];
 }
 
-+ (NSString *)MR_applicationStorageDirectory
++ (NSString *) MR_applicationStorageDirectory
 {
     NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
     return [[self MR_directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];

--- a/MagicalRecord/Core/MagicalRecordShorthand.h
+++ b/MagicalRecord/Core/MagicalRecordShorthand.h
@@ -17,8 +17,8 @@
 + (NSUInteger) countOfEntitiesWithPredicate:(NSPredicate *)searchFilter inContext:(NSManagedObjectContext *)context;
 + (BOOL) hasAtLeastOneEntity;
 + (BOOL) hasAtLeastOneEntityInContext:(NSManagedObjectContext *)context;
-+ (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
-+ (NSNumber *)aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
++ (NSNumber *) aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
++ (NSNumber *) aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
 - (instancetype) objectWithMinValueFor:(NSString *)property;
 - (instancetype) objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 @end

--- a/Tests/Core/MagicalRecord+ActionsTests.m
+++ b/Tests/Core/MagicalRecord+ActionsTests.m
@@ -14,7 +14,7 @@
 
 #pragma mark - Synchronous Saves
 
-- (void)testSynchronousSaveActionSaves
+- (void) testSynchronousSaveActionSaves
 {
     __block NSManagedObjectID *objectId;
 
@@ -37,7 +37,7 @@
     expect([fetchedObject hasChanges]).to.beFalsy();
 }
 
-- (void)testSynchronousSaveActionMakesInsertedEntitiesAvailableInTheDefaultContext
+- (void) testSynchronousSaveActionMakesInsertedEntitiesAvailableInTheDefaultContext
 {
     __block NSManagedObjectID *objectId;
 
@@ -60,7 +60,7 @@
     expect([fetchedObject hasChanges]).to.beFalsy();
 }
 
-- (void)testSynchronousSaveActionMakesUpdatesToEntitiesAvailableToTheDefaultContext
+- (void) testSynchronousSaveActionMakesUpdatesToEntitiesAvailableToTheDefaultContext
 {
     __block NSManagedObjectID *objectId;
     __block NSManagedObject *fetchedObject;
@@ -95,7 +95,7 @@
 
 #pragma mark - Asynchronous Saves
 
-- (void)testAsynchronousSaveActionSaves
+- (void) testAsynchronousSaveActionSaves
 {
     __block BOOL saveSuccessState = NO;
     __block NSError *saveError;
@@ -123,7 +123,7 @@
     expect([existingObject hasChanges]).will.beFalsy();
 }
 
-- (void)testAsynchronousSaveActionCallsCompletionBlockOnTheMainThread
+- (void) testAsynchronousSaveActionCallsCompletionBlockOnTheMainThread
 {
     __block BOOL completionBlockCalled = NO;
     __block BOOL completionBlockIsOnMainThread = NO;
@@ -142,7 +142,7 @@
     expect(completionBlockIsOnMainThread).will.beTruthy();
 }
 
-- (void)testAsynchronousSaveActionMakesInsertedEntitiesAvailableInTheDefaultContext
+- (void) testAsynchronousSaveActionMakesInsertedEntitiesAvailableInTheDefaultContext
 {
     __block BOOL saveSuccessState = NO;
     __block NSManagedObjectID *objectId;
@@ -165,7 +165,7 @@
     expect([fetchedObject hasChanges]).will.beFalsy();
 }
 
-- (void)testAsynchronousSaveActionMakesUpdatesToEntitiesAvailableToTheDefaultContext
+- (void) testAsynchronousSaveActionMakesUpdatesToEntitiesAvailableToTheDefaultContext
 {
     __block NSManagedObjectID *objectId;
     __block NSManagedObject *fetchedObject;
@@ -197,7 +197,7 @@
     expect([fetchedObject valueForKey:kTestAttributeKey]).will.beFalsy();
 }
 
-- (void)testCurrentThreadSynchronousSaveActionSaves
+- (void) testCurrentThreadSynchronousSaveActionSaves
 {
     __block NSManagedObjectID *objectId;
 
@@ -220,7 +220,7 @@
     expect([fetchedObject hasChanges]).to.beFalsy();
 }
 
-- (void)testCurrentThreadAsynchronousSaveActionSaves
+- (void) testCurrentThreadAsynchronousSaveActionSaves
 {
     __block BOOL               saveSuccessState = NO;
     __block NSError           *saveError;
@@ -248,7 +248,7 @@
     expect([fetchedObject hasChanges]).will.beFalsy();
 }
 
-- (void)testCurrentThreadAsynchronousSaveActionCallsCompletionBlockOnTheMainThread
+- (void) testCurrentThreadAsynchronousSaveActionCallsCompletionBlockOnTheMainThread
 {
     __block BOOL completionBlockCalled = NO;
     __block BOOL completionBlockIsOnMainThread = NO;

--- a/Tests/Core/MagicalRecordTestBase.m
+++ b/Tests/Core/MagicalRecordTestBase.m
@@ -8,7 +8,7 @@
 
 @implementation MagicalRecordTestBase
 
-- (void)setUp
+- (void) setUp
 {
     [super setUp];
 
@@ -22,7 +22,7 @@
     [MagicalRecord setupCoreDataStackWithInMemoryStore];
 }
 
-- (void)tearDown
+- (void) tearDown
 {
     [MagicalRecord cleanUp];
 

--- a/Tests/Core/NSManagedObject+MagicalRecordTests.m
+++ b/Tests/Core/NSManagedObject+MagicalRecordTests.m
@@ -15,13 +15,13 @@
 
 @implementation NSManagedObjectMagicalRecord
 
-- (void)testThatInternalEntityNameReturnsClassNameWhenEntityNameMethodIsNotImplemented
+- (void) testThatInternalEntityNameReturnsClassNameWhenEntityNameMethodIsNotImplemented
 {
     expect([EntityWithoutEntityNameMethod MR_entityName]).toNot.beNil();
     expect([EntityWithoutEntityNameMethod MR_entityName]).to.equal(NSStringFromClass([EntityWithoutEntityNameMethod class]));
 }
 
-- (void)testThatInternalEntityNameReturnsProvidedNameWhenEntityNameMethodIsImplemented
+- (void) testThatInternalEntityNameReturnsProvidedNameWhenEntityNameMethodIsImplemented
 {
     expect([EntityWithoutEntityNameMethod MR_entityName]).toNot.beNil();
     expect([DifferentClassNameMapping MR_entityName]).toNot.equal(NSStringFromClass([DifferentClassNameMapping class]));

--- a/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
+++ b/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
@@ -12,7 +12,7 @@
 
 @implementation NSManagedObjectContextMagicalSavesTests
 
-- (void)testSaveToSelfOnlyWhenSaveIsSynchronous
+- (void) testSaveToSelfOnlyWhenSaveIsSynchronous
 {
     NSManagedObjectContext *parentContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_contextWithParent:parentContext];
@@ -48,7 +48,7 @@
     expect([childContextFetchedObject hasChanges]).to.beFalsy();
 }
 
-- (void)testSaveToSelfOnlyWhenSaveIsAsynchronous
+- (void) testSaveToSelfOnlyWhenSaveIsAsynchronous
 {
     NSManagedObjectContext *parentContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_contextWithParent:parentContext];
@@ -89,7 +89,7 @@
     expect([childContextFetchedObject hasChanges]).will.beFalsy();
 }
 
-- (void)testSaveToSelfOnlyWhenSaveIsAsynchronousCallsMainThreadOnCompletion
+- (void) testSaveToSelfOnlyWhenSaveIsAsynchronousCallsMainThreadOnCompletion
 {
     NSManagedObjectContext *defaultContext = [NSManagedObjectContext MR_defaultContext];
 
@@ -109,7 +109,7 @@
     expect(completionBlockIsOnMainThread).will.beTruthy();
 }
 
-- (void)testSaveToPersistentStoreWhenSaveIsSynchronous
+- (void) testSaveToPersistentStoreWhenSaveIsSynchronous
 {
     NSManagedObjectContext *parentContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_contextWithParent:parentContext];
@@ -147,7 +147,7 @@
     expect([childContextFetchedObject hasChanges]).to.beFalsy();
 }
 
-- (void)testSaveToPersistentStoreWhenSaveIsAsynchronous
+- (void) testSaveToPersistentStoreWhenSaveIsAsynchronous
 {
     NSManagedObjectContext *parentContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_contextWithParent:parentContext];
@@ -190,7 +190,7 @@
     expect([childContextFetchedObject hasChanges]).will.beFalsy();
 }
 
-- (void)testThatSavedObjectsHavePermanentIDs
+- (void) testThatSavedObjectsHavePermanentIDs
 {
     NSManagedObjectContext *defaultContext = [NSManagedObjectContext MR_defaultContext];
     SingleEntityWithNoRelationships *entity = [SingleEntityWithNoRelationships MR_createEntityInContext:defaultContext];

--- a/Tests/Core/NSManagedObjectHelperTests.m
+++ b/Tests/Core/NSManagedObjectHelperTests.m
@@ -15,14 +15,14 @@
 
 @implementation NSManagedObjectHelperTests
 
-- (void)testCreateFetchRequestForEntity
+- (void) testCreateFetchRequestForEntity
 {
     NSFetchRequest *testRequest = [SingleRelatedEntity MR_requestAll];
 
     XCTAssertEqualObjects([[testRequest entity] name], NSStringFromClass([SingleRelatedEntity class]), @"Entity name should be the string representation of the entity's class");
 }
 
-- (void)testCanRequestFirstEntityWithPredicate
+- (void) testCanRequestFirstEntityWithPredicate
 {
     NSPredicate *testPredicate = [NSPredicate predicateWithFormat:@"mappedStringAttribute = 'Test Predicate'"];
     NSFetchRequest *testRequest = [SingleRelatedEntity MR_requestFirstWithPredicate:testPredicate];
@@ -31,7 +31,7 @@
     XCTAssertEqualObjects([testRequest predicate], [NSPredicate predicateWithFormat:@"mappedStringAttribute = 'Test Predicate'"], @"Predicate objects should be equal");
 }
 
-- (void)testCreateRequestForFirstEntity
+- (void) testCreateRequestForFirstEntity
 {
     NSFetchRequest *testRequest = [SingleRelatedEntity MR_requestFirstByAttribute:@"mappedStringAttribute" withValue:nil];
 
@@ -41,21 +41,21 @@
     XCTAssertEqualObjects([testRequest predicate], [NSPredicate predicateWithFormat:@"mappedStringAttribute = nil"], @"Predicate objects should be equal");
 }
 
-- (void)testCanGetEntityDescriptionFromEntityClass
+- (void) testCanGetEntityDescriptionFromEntityClass
 {
     NSEntityDescription *testDescription = [SingleRelatedEntity MR_entityDescription];
 
     XCTAssertNotNil(testDescription, @"Entity description should not be nil");
 }
 
-- (void)testCanCreateEntityInstance
+- (void) testCanCreateEntityInstance
 {
     id testEntity = [SingleRelatedEntity MR_createEntity];
 
     XCTAssertNotNil(testEntity, @"Entity should not be nil");
 }
 
-- (void)testCanDeleteEntityInstance
+- (void) testCanDeleteEntityInstance
 {
     id testEntity = [SingleRelatedEntity MR_createEntity];
 
@@ -69,7 +69,7 @@
     XCTAssertTrue([testEntity isDeleted], @"Entity should return true for isDeleted before MR_deleteEntity is sent");
 }
 
-- (void)testCanSearchForNumberOfAllEntities
+- (void) testCanSearchForNumberOfAllEntities
 {
     NSInteger numberOfTestEntitiesToCreate = 20;
 
@@ -79,7 +79,7 @@
     XCTAssertEqualObjects(entityCount, @(numberOfTestEntitiesToCreate), @"Expected numberOfEntities to be %zd, got %@", numberOfTestEntitiesToCreate, entityCount);
 }
 
-- (void)testCanSearchForNumberOfEntitiesWithPredicate
+- (void) testCanSearchForNumberOfEntitiesWithPredicate
 {
     NSInteger numberOfTestEntitiesToCreate = 20;
 
@@ -90,7 +90,7 @@
     XCTAssertEqualObjects(entityCount, @5, @"Should return a count of 5, got %@", entityCount);
 }
 
-- (void)testRetrieveInstanceOfManagedObjectFromAnotherContextHasAPermanentObjectID
+- (void) testRetrieveInstanceOfManagedObjectFromAnotherContextHasAPermanentObjectID
 {
     NSManagedObject *insertedEntity = [SingleRelatedEntity MR_createEntity];
 
@@ -102,7 +102,7 @@
     }];
 }
 
-- (void)testCanDeleteEntityInstanceInOtherContext
+- (void) testCanDeleteEntityInstanceInOtherContext
 {
     NSManagedObjectContext *defaultContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObject *testEntity = [SingleRelatedEntity MR_createEntityInContext:defaultContext];
@@ -131,7 +131,7 @@
 
 #pragma mark - Private Methods
 
-- (void)p_createSampleData:(NSInteger)numberOfTestEntitiesToCreate
+- (void) p_createSampleData:(NSInteger)numberOfTestEntitiesToCreate
 {
     for (int i = 0; i < numberOfTestEntitiesToCreate; i++) {
         SingleRelatedEntity *testEntity = [SingleRelatedEntity MR_createEntity];

--- a/Tests/DataImport/ImportMultipleEntitiesWithNoPrimaryKeyTests.m
+++ b/Tests/DataImport/ImportMultipleEntitiesWithNoPrimaryKeyTests.m
@@ -19,19 +19,19 @@
 
 @implementation ImportMultipleEntitiesWithNoPrimaryKeyTests
 
-- (void)setUp
+- (void) setUp
 {
     [super setUp];
     
     self.arrayOfTestEntity = [SingleEntityWithNoRelationships MR_importFromArray:self.testEntityData];
 }
 
-- (void)tearDown
+- (void) tearDown
 {
     [super tearDown];
 }
 
-- (void)testImportOfMultipleEntities
+- (void) testImportOfMultipleEntities
 {
     XCTAssertNotNil(self.arrayOfTestEntity, @"arrayOfTestEntity should not be nil");
     XCTAssertEqual(self.arrayOfTestEntity.count, (NSUInteger)4, @"arrayOfTestEntity should have 4 entities");

--- a/Tests/DataImport/ImportSingleEntityRelatedToManyMappedEntitiesUsingMappedPrimaryKeyTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToManyMappedEntitiesUsingMappedPrimaryKeyTests.m
@@ -15,12 +15,12 @@
 
 @implementation ImportSingleEntityRelatedToManyMappedEntitiesUsingMappedPrimaryKeyTests
 
-- (Class)testEntityClass
+- (Class) testEntityClass
 {
     return [SingleEntityRelatedToManyMappedEntitiesUsingMappedPrimaryKey class];
 }
 
-- (void)testImportData
+- (void) testImportData
 {
     SingleEntityRelatedToManyMappedEntitiesUsingMappedPrimaryKey *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingDefaultsTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingDefaultsTests.m
@@ -16,12 +16,12 @@
 
 @implementation ImportSingleEntityRelatedToMappedEntityUsingDefaultsTests
 
-- (Class)testEntityClass
+- (Class) testEntityClass
 {
     return [SingleEntityRelatedToMappedEntityUsingDefaults class];
 }
 
-- (void)setupTestData
+- (void) setupTestData
 {
     NSManagedObjectContext *context = [NSManagedObjectContext MR_defaultContext];
 
@@ -36,7 +36,7 @@
     [context MR_saveToPersistentStoreAndWait];
 }
 
-- (void)testImportMappedEntityViaToOneRelationship
+- (void) testImportMappedEntityViaToOneRelationship
 {
     SingleEntityRelatedToMappedEntityUsingDefaults *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
@@ -16,7 +16,7 @@
 
 @implementation ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests
 
-- (void)setupTestData
+- (void) setupTestData
 {
     NSManagedObjectContext *context = [NSManagedObjectContext MR_defaultContext];
 
@@ -28,12 +28,12 @@
     [context MR_saveToPersistentStoreAndWait];
 }
 
-- (Class)testEntityClass
+- (Class) testEntityClass
 {
     return [SingleEntityRelatedToMappedEntityUsingMappedPrimaryKey class];
 }
 
-- (void)testImportMappedEntityRelatedViaToOneRelationship
+- (void) testImportMappedEntityRelatedViaToOneRelationship
 {
     SingleEntityRelatedToMappedEntityUsingMappedPrimaryKey *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 
@@ -59,7 +59,7 @@
     XCTAssertTrue(stringRange.length > 0, @"Did not find 'sample json file' in %@", [testRelatedEntity sampleAttribute]);
 }
 
-- (void)testImportMappedEntityUsingPrimaryRelationshipKey
+- (void) testImportMappedEntityUsingPrimaryRelationshipKey
 {
     SingleEntityRelatedToMappedEntityUsingMappedPrimaryKey *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityWithNestedMappedAttributesTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityWithNestedMappedAttributesTests.m
@@ -16,12 +16,12 @@
 
 @implementation ImportSingleEntityRelatedToMappedEntityWithNestedMappedAttributesTests
 
-- (Class)testEntityClass
+- (Class) testEntityClass
 {
     return [SingleEntityRelatedToMappedEntityWithNestedMappedAttributes class];
 }
 
-- (void)testDataImport
+- (void) testDataImport
 {
     SingleEntityRelatedToMappedEntityWithNestedMappedAttributes *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityWithSecondaryMappingsTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityWithSecondaryMappingsTests.m
@@ -15,12 +15,12 @@
 
 @implementation ImportSingleEntityRelatedToMappedEntityWithSecondaryMappingsTests
 
-- (Class)testEntityClass
+- (Class) testEntityClass
 {
     return [SingleEntityRelatedToMappedEntityWithSecondaryMappings class];
 }
 
-- (void)testImportMappedAttributeUsingSecondaryMappedKeyName
+- (void) testImportMappedAttributeUsingSecondaryMappedKeyName
 {
     SingleEntityRelatedToMappedEntityWithSecondaryMappings *entity = [[self testEntityClass] MR_importFromObject:self.testEntityData];
 

--- a/Tests/DataImport/ImportSingleEntityWithNoRelationshipsTests.m
+++ b/Tests/DataImport/ImportSingleEntityWithNoRelationshipsTests.m
@@ -20,7 +20,7 @@
 
 @synthesize testEntity;
 
-- (void)setUp
+- (void) setUp
 {
     [super setUp];
 
@@ -32,79 +32,79 @@
     testEntity = [SingleEntityWithNoRelationships MR_importFromObject:singleEntity];
 }
 
-- (void)tearDown
+- (void) tearDown
 {
     [super tearDown];
 
     [MagicalRecord cleanUp];
 }
 
-- (void)testImportASingleEntity
+- (void) testImportASingleEntity
 {
     XCTAssertNotNil(testEntity, @"testEntity should not be nil");
 }
 
-- (void)testImportStringAttributeToEntity
+- (void) testImportStringAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.stringTestAttribute, @"This is a test value", @"stringTestAttribute did not contain expected value, instead found '%@'", testEntity.stringTestAttribute);
 }
 
-- (void)testImportInt16AttributeToEntity
+- (void) testImportInt16AttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.int16TestAttribute, @256, @"int16TestAttribute did not contain expected value, instead found: %@", testEntity.int16TestAttribute);
 }
 
-- (void)testImportInt32AttributeToEntity
+- (void) testImportInt32AttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.int32TestAttribute, @32, @"int32TestAttribute did not contain expected value, instead found: %@", testEntity.int32TestAttribute);
 }
 
-- (void)testImportInt64AttributeToEntity
+- (void) testImportInt64AttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.int64TestAttribute, @42, @"int64TestAttribute did not contain expected value, instead found: %@", testEntity.int64TestAttribute);
 }
 
-- (void)testImportDecimalAttributeToEntity
+- (void) testImportDecimalAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.decimalTestAttribute, @1.2, @"decimalTestAttribute did not contain expected value, instead found: %@", testEntity.decimalTestAttribute);
 }
 
-- (void)testImportDoubleAttributeToEntity
+- (void) testImportDoubleAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.doubleTestAttribute, @124.3, @"doubleTestAttribute did not contain expected value, instead found: %@", testEntity.doubleTestAttribute);
 }
 
-- (void)testImportFloatAttributeToEntity
+- (void) testImportFloatAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.floatTestAttribute, @10000000000, @"floatTestAttribute did not contain expected value, instead found: %@", testEntity.floatTestAttribute);
 }
 
-- (void)testImportBooleanAttributeToEntity
+- (void) testImportBooleanAttributeToEntity
 {
     XCTAssertFalse([testEntity.booleanTestAttribute boolValue], @"booleanTestAttribute did not contain expected value, instead found: %@", testEntity.booleanTestAttribute);
 }
 
-- (void)testImportMappedStringAttributeToEntity
+- (void) testImportMappedStringAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.mappedStringAttribute, @"Mapped value", @"mappedStringAttribute did not contain expected value, instead found: %@", testEntity.mappedStringAttribute);
 }
 
-- (void)testImportStringAttributeWithNullValue
+- (void) testImportStringAttributeWithNullValue
 {
     XCTAssertNil(testEntity.nullTestAttribute, @"nullTestAttribute did not contain expected value, instead found: %@", testEntity.nullTestAttribute);
 }
 
-- (void)testImportNumberAsStringAttributeToEntity
+- (void) testImportNumberAsStringAttributeToEntity
 {
     XCTAssertEqualObjects(testEntity.numberAsStringTestAttribute, @"10248909829", @"numberAsStringTestAttribute did not contain expected value, instead found: %@", testEntity.numberAsStringTestAttribute);
 }
 
-- (void)testImportBooleanAsStringAttributeToEntity
+- (void) testImportBooleanAsStringAttributeToEntity
 {
     XCTAssertTrue(testEntity.booleanAsStringTestAttribute, @"booleanFromStringTestAttribute did not contain expected value, instead found: %@", testEntity.booleanAsStringTestAttribute);
 }
 
-- (void)testImportAttributeNotInJsonData
+- (void) testImportAttributeNotInJsonData
 {
     NSRange rangeOfString = [testEntity.notInJsonAttribute rangeOfString:@"Core Data Model"];
 
@@ -115,7 +115,7 @@
 
 #if defined(__IPHONE_5_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_5_0
 
-- (void)testImportUIColorAttributeToEntity
+- (void) testImportUIColorAttributeToEntity
 {
     UIColor *actualColor = testEntity.colorTestAttribute;
 
@@ -131,7 +131,7 @@
 }
 #endif
 
-- (NSDate *)dateFromString:(NSString *)date
+- (NSDate *) dateFromString:(NSString *)date
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 
@@ -146,7 +146,7 @@
 
 #else
 
-- (void)testImportNSColorAttributeToEntity
+- (void) testImportNSColorAttributeToEntity
 {
     NSColor *actualColor = testEntity.colorTestAttribute;
 
@@ -156,7 +156,7 @@
     XCTAssertEqual([actualColor blueComponent], (CGFloat)(225.0f / 255.0f), @"Unexpected value returned");
 }
 
-- (NSDate *)dateFromString:(NSString *)date
+- (NSDate *) dateFromString:(NSString *)date
 {
     NSDate *expectedDate = [NSDate dateWithString:date];
 
@@ -164,25 +164,25 @@
 }
 #endif /* if TARGET_OS_IPHONE */
 
-- (void)testImportDateAttributeToEntity
+- (void) testImportDateAttributeToEntity
 {
     NSDate *expectedDate = [self dateFromString:@"2011-07-23 22:30:40 +0000"];
 
     XCTAssertEqualObjects(testEntity.dateTestAttribute, expectedDate, @"Unexpected value returned");
 }
 
-- (void)testImportDateAttributeWithCustomFormat
+- (void) testImportDateAttributeWithCustomFormat
 {
     NSDate *expectedDate = [self dateFromString:@"2011-08-05 01:56:04 +0000"];
 
     XCTAssertEqualObjects(testEntity.dateWithCustomFormat, expectedDate, @"Unexpected value returned");
 }
 
-- (void)testImportEpochDate {
+- (void) testImportEpochDate {
     XCTAssertEqualObjects(testEntity.unixTimeTestAttribute, [NSDate dateWithTimeIntervalSince1970:1388349428], @"unixTimeTestAttribute did not contain the expected value, instead found: %@", testEntity.unixTimeTestAttribute);
 }
 
-- (void)testImportEpochDate13 {
+- (void) testImportEpochDate13 {
     XCTAssertEqualObjects(testEntity.unixTime13TestAttribute, [NSDate dateWithTimeIntervalSince1970:1388349427.543], @"unixTimeTest13Attribute did not contain the expected value, instead found: %@", testEntity.unixTime13TestAttribute);
 }
 

--- a/Tests/DataImport/ImportSingleRelatedEntityTests.m
+++ b/Tests/DataImport/ImportSingleRelatedEntityTests.m
@@ -22,7 +22,7 @@
 
 @synthesize singleTestEntity = _singleTestEntity;
 
-- (void)setupTestData
+- (void) setupTestData
 {
     NSManagedObjectContext *context = [NSManagedObjectContext MR_defaultContext];
 
@@ -34,7 +34,7 @@
     [context MR_saveToPersistentStoreAndWait];
 }
 
-- (void)setUp
+- (void) setUp
 {
     [super setUp];
 
@@ -42,7 +42,7 @@
     [[NSManagedObjectContext MR_defaultContext] MR_saveToPersistentStoreAndWait];
 }
 
-- (void)testImportAnEntityRelatedToAbstractEntityViaToOneRelationshop
+- (void) testImportAnEntityRelatedToAbstractEntityViaToOneRelationshop
 {
     XCTAssertNotNil(self.singleTestEntity, @"singleTestEntity should not be nil");
 
@@ -56,7 +56,7 @@
     XCTAssertFalse([testRelatedEntity respondsToSelector:@selector(sampleConcreteAttribute)], @"testRelatedEntity should respond to selector sampleConcreteAttribute");
 }
 
-- (void)testImportAnEntityRelatedToAbstractEntityViaToManyRelationship
+- (void) testImportAnEntityRelatedToAbstractEntityViaToManyRelationship
 {
     XCTAssertNotNil(self.singleTestEntity, @"singleTestEntity should not be nil");
 
@@ -75,7 +75,7 @@
 
 #pragma mark - Subentity tests
 
-- (void)testImportAnEntityRelatedToAConcreteSubEntityViaToOneRelationship
+- (void) testImportAnEntityRelatedToAConcreteSubEntityViaToOneRelationship
 {
     id testRelatedEntity = self.singleTestEntity.testConcreteToOneRelationship;
 
@@ -88,7 +88,7 @@
     XCTAssertTrue(stringRange.length > 0, @"Expected to find 'DESCENDANT' in string '%@' but did not", [testRelatedEntity sampleConcreteAttribute]);
 }
 
-- (void)testImportAnEntityRelatedToASubEntityViaToManyRelationship
+- (void) testImportAnEntityRelatedToASubEntityViaToManyRelationship
 {
     NSUInteger relationshipCount = [self.singleTestEntity.testConcreteToManyRelationship count];
     XCTAssertEqual(relationshipCount, (NSUInteger)3, @"Expected relationship count to be 3, received %zd", relationshipCount);

--- a/Tests/DataImport/MagicalDataImportTestCase.m
+++ b/Tests/DataImport/MagicalDataImportTestCase.m
@@ -11,7 +11,7 @@
 
 @implementation MagicalDataImportTestCase
 
-- (void)setUp
+- (void) setUp
 {
     [super setUp];
 
@@ -20,12 +20,12 @@
     self.testEntityData = [self dataFromJSONFixture];
 }
 
-- (Class)testEntityClass;
+- (Class) testEntityClass;
 {
     return [NSManagedObject class];
 }
 
-- (void)setupTestData
+- (void) setupTestData
 {
     // Implement this in your subclasses
 }


### PR DESCRIPTION
Fixed coding conventions of method. I added a space after the method's
return type.

sorry for sending small changed PR. 
But, That part bothers me. 
