### PR TITLE
Fix: Crash when entityName not implemented.

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -13,7 +13,7 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 
 + (NSString *) MR_entityName;
 {
-    NSString *entityName;
+    NSString *entityName = @"";
 
     if ([self respondsToSelector:@selector(entityName)])
     {


### PR DESCRIPTION
Fix for a minor bug when entityName is not implemented in
NSManagedObject subclass which was causing a crash for Attempt to
dereference an invalid ObjC Object.
