### PR TITLE
Added back public method in MagicalDataImport

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.h
@@ -28,6 +28,8 @@ extern NSString * const kMagicalRecordImportRelationshipTypeKey;
 
 @interface NSManagedObject (MagicalRecord_DataImport) <MagicalRecordDataImportProtocol>
 
+- (BOOL) MR_importValuesForKeysWithObject:(id)objectData;
+
 + (instancetype) MR_importFromObject:(id)data;
 + (instancetype) MR_importFromObject:(id)data inContext:(NSManagedObjectContext *)context;
 


### PR DESCRIPTION
This adds `- (BOOL) MR_importValuesForKeysWithObject:(id)objectData;` back into the public interface for `NSManagedObject+MagicalDataImport.h`.

Fixes #821
