### PR TITLE
Removed Exception logic when creating relationships

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -168,26 +168,21 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         
         NSString *lookupKey = [[relationshipInfo userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
 
-        id relatedObjectData;
-
-        @try
-        {
+        id relatedObjectData = nil;
+        
+        if ([relationshipData isKindOfClass:[NSDictionary class]]) {
             relatedObjectData = [relationshipData valueForKeyPath:lookupKey];
         }
-        @catch (NSException *exception)
-        {
+        else {
             MRLogWarn(@"Looking up a key for relationship failed while importing: %@\n", relationshipInfo);
             MRLogWarn(@"lookupKey: %@", lookupKey);
             MRLogWarn(@"relationshipInfo.destinationEntity %@", [relationshipInfo destinationEntity]);
             MRLogWarn(@"relationshipData: %@", relationshipData);
-            MRLogWarn(@"Exception:\n%@: %@", [exception name], [exception reason]);
         }
-        @finally
+        
+        if (relatedObjectData == nil || [relatedObjectData isEqual:[NSNull null]])
         {
-            if (relatedObjectData == nil || [relatedObjectData isEqual:[NSNull null]])
-            {
-                continue;
-            }
+            continue;
         }
         
         SEL shouldImportSelector = NSSelectorFromString([NSString stringWithFormat:@"shouldImport%@:", [relationshipName MR_capitalizedFirstCharacterString]]);


### PR DESCRIPTION
Replaced exception handling in `MR_setRelationships:forKeysWithObjects:withBlock:` by checking for the correct type before accessing values.

According to [Apple](https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/ErrorHandling/ErrorHandling.html)
> You should not use a try-catch block in place of standard programming checks for Objective-C methods.