### PR TITLE
Use context passed in as parameter instead of +MR_contextForCurrentThrea...

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -372,14 +372,11 @@
                                                 ascending:ascending
                                             withPredicate:searchTerm
                                                 inContext:context];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	NSFetchedResultsController *controller = [self MR_fetchController:request 
+	NSFetchedResultsController *controller = [self MR_fetchController:request
                                                              delegate:nil
                                                          useFileCache:NO
                                                             groupedBy:groupingKeyPath
-                                                            inContext:[NSManagedObjectContext MR_contextForCurrentThread]];
-#pragma clang diagnostic pop
+                                                            inContext:context];
 
     [self MR_performFetch:controller];
     return controller;


### PR DESCRIPTION
...d

Previously, this method used the context supplied as a parameter
to create the fetch request, but then used `[NSManagedObjectContext
MR_contextForCurrentThread]` to create the
`NSFetchedResultsController`.
It will now correctly use the provided context for both the fetch
request and the `NSFetchedResultsController`.
