### PR TITLE
- now possible create all contexts only on bacground NSOperationQueue, f...

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
@@ -11,6 +11,7 @@
 #import "MagicalRecord.h"
 #import "MagicalRecord+iCloud.h"
 #import "MagicalRecordLogging.h"
+#import "MagicalRecord+Setup.h"
 
 NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalRecordDidMergeChangesFromiCloudNotification";
 
@@ -53,7 +54,7 @@ NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification = @"kMagica
         
         MRLogVerbose(@"Merging changes From iCloud %@context%@",
               self == [NSManagedObjectContext MR_defaultContext] ? @"*** DEFAULT *** " : @"",
-              ([NSThread isMainThread] ? @" *** on Main Thread ***" : @""));
+              ([NSOperationQueue currentQueue] == CoreDataMainThread ? @" *** on Main Thread ***" : @""));
         
         [self mergeChangesFromContextDidSaveNotification:notification];
         
@@ -69,14 +70,14 @@ NSString * const kMagicalRecordDidMergeChangesFromiCloudNotification = @"kMagica
 {
 	MRLogVerbose(@"Merging changes to %@context%@",
           self == [NSManagedObjectContext MR_defaultContext] ? @"*** DEFAULT *** " : @"",
-          ([NSThread isMainThread] ? @" *** on Main Thread ***" : @""));
+          ([NSOperationQueue currentQueue] == CoreDataMainThread ? @" *** on Main Thread ***" : @""));
     
 	[self mergeChangesFromContextDidSaveNotification:notification];
 }
 
 - (void) MR_mergeChangesOnMainThread:(NSNotification *)notification;
 {
-	if ([NSThread isMainThread])
+	if ([NSOperationQueue currentQueue] == CoreDataMainThread)
 	{
 		[self MR_mergeChangesFromNotification:notification];
 	}

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -11,6 +11,7 @@
 #import "NSManagedObjectContext+MagicalRecord.h"
 #import "MagicalRecord.h"
 #import "MagicalRecordLogging.h"
+#import "MagicalRecord+Setup.h"
 
 @implementation NSManagedObjectContext (MagicalSaves)
 
@@ -31,7 +32,9 @@
 
 - (void) MR_saveToPersistentStoreAndWait;
 {
-    [self MR_saveWithOptions:MRSaveParentContexts | MRSaveSynchronously completion:nil];
+    @synchronized(self.class){
+        [self MR_saveWithOptions:MRSaveParentContexts | MRSaveSynchronously completion:nil];
+    }
 }
 
 - (void) MR_saveWithOptions:(MRSaveOptions)saveOptions completion:(MRSaveCompletionHandler)completion;
@@ -55,9 +58,9 @@
 
         if (completion)
         {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            [CoreDataMainThread addOperationWithBlock:^{
                 completion(NO, nil);
-            });
+            }];
         }
 
         return;
@@ -116,9 +119,9 @@
 
                 if (completion)
                 {
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    [CoreDataMainThread addOperationWithBlock:^{
                         completion(saveResult, error);
-                    });
+                    }];
                 }
             }
         }

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalThreading.m
@@ -10,6 +10,7 @@
 #import "NSManagedObject+MagicalRecord.h"
 #import "NSManagedObjectContext+MagicalRecord.h"
 #include <libkern/OSAtomic.h>
+#import "MagicalRecord+Setup.h"
 
 static NSString const * kMagicalRecordManagedObjectContextKey = @"MagicalRecord_NSManagedObjectContextForThreadKey";
 static NSString const * kMagicalRecordManagedObjectContextCacheVersionKey = @"MagicalRecord_CacheVersionOfNSManagedObjectContextForThreadKey";
@@ -30,7 +31,7 @@ static volatile int32_t contextsCacheVersion = 0;
 
 + (NSManagedObjectContext *) MR_contextForCurrentThread;
 {
-	if ([NSThread isMainThread])
+	if ([NSOperationQueue currentQueue] == CoreDataMainThread)
 	{
 		return [self MR_defaultContext];
 	}

--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -169,8 +169,7 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
             [self MR_addSqliteStoreNamed:storeIdentifier withOptions:options];
             [self unlock];
         }
-
-        dispatch_async(dispatch_get_main_queue(), ^{
+        [CoreDataMainThread addOperationWithBlock:^{
             if ([NSPersistentStore MR_defaultPersistentStore] == nil)
             {
                 [NSPersistentStore MR_setDefaultPersistentStore:[[self persistentStores] firstObject]];
@@ -181,7 +180,7 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
             }
             NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
             [notificationCenter postNotificationName:kMagicalRecordPSCDidCompleteiCloudSetupNotification object:nil];
-        });
+        }];
     });
 }
 

--- a/MagicalRecord/Core/MagicalRecord+Setup.h
+++ b/MagicalRecord/Core/MagicalRecord+Setup.h
@@ -8,9 +8,25 @@
 
 #import "MagicalRecord.h"
 
+/**
+ use it to access to DefaultContexts and as queue for NSFetchedResultsController
+ 
+ if CoreDataMainThread != mainThread,
+ 
+ NSFetchedResultsController mast be created and inited on thread of it context!!!
+*/
+
 #define CoreDataMainThread [MagicalRecord MR_mainThread]
 
 @interface MagicalRecord (Setup)
+
+/**
+ Setup this before setup core data stack, use for it:
+ 
+        [MagicalRecord MR_setMainThread:CoreDataMainQueue];
+ generate assert if called after stack setup. 
+ defuel value = MainQueue
+*/
 
 + (void)MR_setMainThread:(NSOperationQueue*)queue;//default thread = MainQueue
 + (NSOperationQueue*)MR_mainThread;

--- a/MagicalRecord/Core/MagicalRecord+Setup.h
+++ b/MagicalRecord/Core/MagicalRecord+Setup.h
@@ -8,7 +8,12 @@
 
 #import "MagicalRecord.h"
 
+#define CoreDataMainThread [MagicalRecord MR_mainThread]
+
 @interface MagicalRecord (Setup)
+
++ (void)MR_setMainThread:(NSOperationQueue*)queue;//default thread = MainQueue
++ (NSOperationQueue*)MR_mainThread;
 
 + (void) setupCoreDataStack;
 + (void) setupCoreDataStackWithInMemoryStore;

--- a/MagicalRecord/Core/MagicalRecord+Setup.m
+++ b/MagicalRecord/Core/MagicalRecord+Setup.m
@@ -24,7 +24,7 @@ static NSOperationQueue *coreDataMainQueue;
 + (void)MR_setMainThread:(NSOperationQueue*)queue
 {
     queue.maxConcurrentOperationCount = 1;
-//    NSAssert([NSManagedObjectContext MR_defaultContext] == nil, @"main thread mast be seted before coreData stack setup");
+    NSAssert([NSManagedObjectContext MR_defaultContext] == nil, @"main thread mast be seted before coreData stack setup");
     coreDataMainQueue = queue;
 }
 

--- a/MagicalRecord/Core/MagicalRecord+Setup.m
+++ b/MagicalRecord/Core/MagicalRecord+Setup.m
@@ -13,6 +13,26 @@
 
 @implementation MagicalRecord (Setup)
 
+
+static NSOperationQueue *coreDataMainQueue;
+
++ (void)load
+{
+    coreDataMainQueue = [NSOperationQueue mainQueue];
+}
+
++ (void)MR_setMainThread:(NSOperationQueue*)queue
+{
+//    NSAssert([NSManagedObjectContext MR_defaultContext] == nil, @"main thread mast be seted before coreData stack setup");
+    coreDataMainQueue = queue;
+}
+
++ (NSOperationQueue*)MR_mainThread
+{
+    return coreDataMainQueue;
+}
+
+
 + (void) setupCoreDataStack
 {
     [self setupCoreDataStackWithStoreNamed:[self defaultStoreName]];

--- a/MagicalRecord/Core/MagicalRecord+Setup.m
+++ b/MagicalRecord/Core/MagicalRecord+Setup.m
@@ -23,6 +23,7 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void)MR_setMainThread:(NSOperationQueue*)queue
 {
+    queue.maxConcurrentOperationCount = 1;
 //    NSAssert([NSManagedObjectContext MR_defaultContext] == nil, @"main thread mast be seted before coreData stack setup");
     coreDataMainQueue = queue;
 }
@@ -35,16 +36,22 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void) setupCoreDataStack
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     [self setupCoreDataStackWithStoreNamed:[self defaultStoreName]];
 }
 
 + (void) setupAutoMigratingCoreDataStack
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     [self setupCoreDataStackWithAutoMigratingSqliteStoreNamed:[self defaultStoreName]];
 }
 
 + (void) setupCoreDataStackWithStoreNamed:(NSString *)storeName
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     if ([NSPersistentStoreCoordinator MR_defaultStoreCoordinator] != nil) return;
     
 	NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithSqliteStoreNamed:storeName];
@@ -55,6 +62,8 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void) setupCoreDataStackWithAutoMigratingSqliteStoreNamed:(NSString *)storeName
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     if ([NSPersistentStoreCoordinator MR_defaultStoreCoordinator] != nil) return;
     
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithAutoMigratingSqliteStoreNamed:storeName];
@@ -65,6 +74,8 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void) setupCoreDataStackWithStoreAtURL:(NSURL *)storeURL
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     if ([NSPersistentStoreCoordinator MR_defaultStoreCoordinator] != nil) return;
     
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithSqliteStoreAtURL:storeURL];
@@ -75,6 +86,8 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void) setupCoreDataStackWithAutoMigratingSqliteStoreAtURL:(NSURL *)storeURL
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     if ([NSPersistentStoreCoordinator MR_defaultStoreCoordinator] != nil) return;
     
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithAutoMigratingSqliteStoreAtURL:storeURL];
@@ -85,6 +98,8 @@ static NSOperationQueue *coreDataMainQueue;
 
 + (void) setupCoreDataStackWithInMemoryStore;
 {
+    NSAssert([NSOperationQueue mainQueue] == CoreDataMainThread, @"core data stack setup mast be called from CoreDataMainThread");
+    
     if ([NSPersistentStoreCoordinator MR_defaultStoreCoordinator] != nil) return;
     
 	NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithInMemoryStore];

--- a/Tests/Core/MagicalRecordStackTests.m
+++ b/Tests/Core/MagicalRecordStackTests.m
@@ -54,8 +54,13 @@
 
 - (void)testCreateBackgroundCoreDataStack
 {    
+    XCTAssertTrue(CoreDataMainThread != nil, @"CoreDataMainThread mast not bee nil");
+    
     NSOperationQueue *backgroundQueue = [[NSOperationQueue alloc] init];    
     [MagicalRecord MR_setMainThread:backgroundQueue];
+    
+    XCTAssertTrue(CoreDataMainThread != nil, @"CoreDataMainThread mast not bee nil");
+    XCTAssertTrue(backgroundQueue == CoreDataMainThread, @"CoreDataMainThread mast not bee nil");
     
     [self testCreateDefaultCoreDataStack];
 }

--- a/Tests/Core/MagicalRecordStackTests.m
+++ b/Tests/Core/MagicalRecordStackTests.m
@@ -52,6 +52,14 @@
     [MagicalRecord cleanUp];
 }
 
+- (void)testCreateBackgroundCoreDataStack
+{    
+    NSOperationQueue *backgroundQueue = [[NSOperationQueue alloc] init];    
+    [MagicalRecord MR_setMainThread:backgroundQueue];
+    
+    [self testCreateDefaultCoreDataStack];
+}
+
 - (void) testCreateInMemoryCoreDataStack
 {
     [MagicalRecord setupCoreDataStackWithInMemoryStore];


### PR DESCRIPTION
...or in - call [MagicalRecord MR_setMainThread:queue];

- dispatch_async replaced on NSOperationQueue addOperationWithBlock