### PR TITLE
Added a 3rd condition for the migration error case

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -86,7 +86,7 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
     {
         if ([MagicalRecord shouldDeleteStoreOnModelMismatch])
         {
-            BOOL isMigrationError = (([error code] == NSPersistentStoreIncompatibleVersionHashError) || ([error code] == NSMigrationMissingSourceModelError));
+            BOOL isMigrationError = (([error code] == NSPersistentStoreIncompatibleVersionHashError) || ([error code] == NSMigrationMissingSourceModelError) || ([error code] == NSMigrationError));
             if ([[error domain] isEqualToString:NSCocoaErrorDomain] && isMigrationError)
             {
                 [[NSNotificationCenter defaultCenter] postNotificationName:kMagicalRecordPSCMismatchWillDeleteStore object:nil];


### PR DESCRIPTION
In case the error from adding a persistent store is NSMigrationError delete the local store.
