### PR TITLE
Update logging

### DIFF
--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -28,9 +28,6 @@ EOS
     sp.source_files = 'MagicalRecord/**/*.{h,m}'
     sp.prefix_header_contents = <<-EOS
 #import <CoreData/CoreData.h>
-#if defined(COCOAPODS_POD_AVAILABLE_CocoaLumberjack)
-  #import "DDLog.h"
-#endif
 #define MR_LOGGING_ENABLED 1
 #import "CoreData+MagicalRecord.h"
 EOS
@@ -53,9 +50,6 @@ EOS
     sp.source_files = 'MagicalRecord/**/*.{h,m}'
     sp.prefix_header_contents = <<-EOS
 #import <CoreData/CoreData.h>
-#if defined(COCOAPODS_POD_AVAILABLE_CocoaLumberjack)
-  #import "DDLog.h"
-#endif
 #define MR_LOGGING_ENABLED 1
 #define MR_SHORTHAND 1
 #import "CoreData+MagicalRecord.h"

--- a/MagicalRecord/Core/MagicalRecord+Options.m
+++ b/MagicalRecord/Core/MagicalRecord+Options.m
@@ -8,7 +8,11 @@
 
 #import "MagicalRecord+Options.h"
 
-static MagicalRecordLoggingLevel kMagicalRecordLoggingLevel = MagicalRecordLoggingLevelVerbose;
+#ifdef DEBUG
+static MagicalRecordLoggingLevel kMagicalRecordLoggingLevel = MagicalRecordLoggingLevelInfo;
+#else
+static MagicalRecordLoggingLevel kMagicalRecordLoggingLevel = MagicalRecordLoggingLevelError;
+#endif
 static BOOL kMagicalRecordShouldAutoCreateManagedObjectModel = NO;
 static BOOL kMagicalRecordShouldAutoCreateDefaultPersistentStoreCoordinator = NO;
 static BOOL kMagicalRecordShouldDeleteStoreOnModelMismatch = NO;

--- a/MagicalRecord/Core/MagicalRecordLogging.h
+++ b/MagicalRecord/Core/MagicalRecordLogging.h
@@ -6,68 +6,43 @@
 //  Copyright (c) 2013 Magical Panda Software LLC. All rights reserved.
 //
 
-#ifndef MagicalRecord_MagicalRecordLogging_h
-#define MagicalRecord_MagicalRecordLogging_h
-
 #import "MagicalRecord.h"
 #import "MagicalRecord+Options.h"
 
-#define LOG_ASYNC_ENABLED YES
+#if !defined(MR_LOGGING_ENABLED) && __has_include("CocoaLumberjack.h")
+    #define MR_LOGGING_ENABLED 1
+#endif
 
-#define LOG_ASYNC_ERROR   ( NO && LOG_ASYNC_ENABLED)
-#define LOG_ASYNC_WARN    (YES && LOG_ASYNC_ENABLED)
-#define LOG_ASYNC_INFO    (YES && LOG_ASYNC_ENABLED)
-#define LOG_ASYNC_VERBOSE (YES && LOG_ASYNC_ENABLED)
+#if MR_LOGGING_ENABLED
 
 #ifndef MR_LOGGING_CONTEXT
     #define MR_LOGGING_CONTEXT 0
 #endif
 
-#ifdef MR_LOGGING_ENABLED
-
-#ifndef LOG_MACRO
-
-    #define LOG_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, ...) \
-    NSLog (frmt, ##__VA_ARGS__)
-
-    #define LOG_MAYBE(async, lvl, flg, ctx, fnct, frmt, ...) \
-    do { if ((lvl & flg) == flg) { LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } } while(0)
-
-    #define LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-    LOG_MAYBE(async, lvl, flg, ctx, sel_getName(_cmd), frmt, ##__VA_ARGS__)
-
-    #define LOG_C_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-    LOG_MAYBE(async, lvl, flg, ctx, __FUNCTION__, frmt, ##__VA_ARGS__)
-
+#if __has_include("CocoaLumberjack.h")
+    #define LOG_LEVEL_DEF (DDLogLevel)[MagicalRecord loggingLevel]
+    #define CAST (DDLogFlag)
+    #import "CocoaLumberjack.h"
+#else
+    #define LOG_LEVEL_DEF [MagicalRecord loggingLevel]
+    #define LOG_ASYNC_ENABLED YES
+    #define CAST
+    #define LOG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) do { if ((lvl & flg) == flg) { NSLog (frmt, ##__VA_ARGS__); } } while(0)
 #endif
 
-#define MRLogFatal(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_ERROR,   [MagicalRecord loggingLevel], MagicalRecordLoggingMaskFatal,   MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogError(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_ERROR,   [MagicalRecord loggingLevel], MagicalRecordLoggingMaskError,   MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogWarn(frmt, ...)    LOG_OBJC_MAYBE(LOG_ASYNC_WARN,    [MagicalRecord loggingLevel], MagicalRecordLoggingMaskWarn,    MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogInfo(frmt, ...)    LOG_OBJC_MAYBE(LOG_ASYNC_INFO,    [MagicalRecord loggingLevel], MagicalRecordLoggingMaskInfo,    MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogVerbose(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_VERBOSE, [MagicalRecord loggingLevel], MagicalRecordLoggingMaskVerbose, MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-
-#define MRLogCFatal(frmt, ...)   LOG_C_MAYBE(LOG_ASYNC_ERROR,   [MagicalRecord loggingLevel], MagicalRecordLoggingMaskFatal,   MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogCError(frmt, ...)   LOG_C_MAYBE(LOG_ASYNC_ERROR,   [MagicalRecord loggingLevel], MagicalRecordLoggingMaskError,   MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogCWarn(frmt, ...)    LOG_C_MAYBE(LOG_ASYNC_WARN,    [MagicalRecord loggingLevel], MagicalRecordLoggingMaskWarn,    MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogCInfo(frmt, ...)    LOG_C_MAYBE(LOG_ASYNC_INFO,    [MagicalRecord loggingLevel], MagicalRecordLoggingMaskInfo,    MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define MRLogCVerbose(frmt, ...) LOG_C_MAYBE(LOG_ASYNC_VERBOSE, [MagicalRecord loggingLevel], MagicalRecordLoggingMaskVerbose, MR_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
+#define MRLogFatal(frmt, ...)   LOG_MAYBE(NO,                LOG_LEVEL_DEF, CAST MagicalRecordLoggingMaskFatal,   MR_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define MRLogError(frmt, ...)   LOG_MAYBE(NO,                LOG_LEVEL_DEF, CAST MagicalRecordLoggingMaskError,   MR_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define MRLogWarn(frmt, ...)    LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, CAST MagicalRecordLoggingMaskWarn,    MR_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define MRLogInfo(frmt, ...)    LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, CAST MagicalRecordLoggingMaskInfo,    MR_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define MRLogVerbose(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, CAST MagicalRecordLoggingMaskVerbose, MR_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
 #else
 
-#define MRLogFatal(frmt, ...) ((void)0)
-#define MRLogError(frmt, ...) ((void)0)
-#define MRLogWarn(frmt, ...) ((void)0)
-#define MRLogInfo(frmt, ...) ((void)0)
+#define MRLogFatal(frmt, ...)   ((void)0)
+#define MRLogError(frmt, ...)   ((void)0)
+#define MRLogWarn(frmt, ...)    ((void)0)
+#define MRLogInfo(frmt, ...)    ((void)0)
 #define MRLogVerbose(frmt, ...) ((void)0)
-
-#define MRLogCFatal(frmt, ...) ((void)0)
-#define MRLogCError(frmt, ...) ((void)0)
-#define MRLogCWarn(frmt, ...) ((void)0)
-#define MRLogCInfo(frmt, ...) ((void)0)
-#define MRLogCVerbose(frmt, ...) ((void)0)
-
-#endif
 
 #endif
 


### PR DESCRIPTION
* Update support for CocoaLumberjack 2.0.0-beta4. 
* Auto-enable logging when CocoaLumberjack is detected.
* Adjust default MagicalRecordLoggingLevel according to build configuration.