### PR TITLE
MR_inContext concurrency fix

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -281,7 +281,12 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
     
     if ([[self objectID] isTemporaryID])
     {
-        BOOL success = [[self managedObjectContext] obtainPermanentIDsForObjects:@[self] error:&error];
+        __block BOOL success = NO;
+        [self.managedObjectContext performBlockAndWait:^{
+            
+            success = [[self managedObjectContext] obtainPermanentIDsForObjects:@[self] error:&error];
+            
+        }];
         if (!success)
         {
             [MagicalRecord handleErrors:error];

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -277,7 +277,7 @@ static NSUInteger defaultBatchSize = kMagicalRecordDefaultBatchSize;
 
 - (id) MR_inContext:(NSManagedObjectContext *)otherContext
 {
-    NSError *error = nil;
+    __block NSError *error = nil;
     
     if ([[self objectID] isTemporaryID])
     {


### PR DESCRIPTION
If `MR_inContext` is called on an `NSManagedObject` that has not yet
been saved, `MagicalRecord` first calls
`-obtainPermanentIDsForObjects:error:` on the `NSManagedObjectContext`
of the temporary object. However, if the two contexts are on different
queues this will result in a concurrency exception (if concurrency
debug is turned on in the scheme).