### PR TITLE
Fix for #923

### DIFF
--- a/Library/MagicalRecordStack/AutoMigratingMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/AutoMigratingMagicalRecordStack.m
@@ -9,6 +9,7 @@
 #import "MagicalRecordStack+Private.h"
 #import "AutoMigratingMagicalRecordStack.h"
 #import "NSPersistentStoreCoordinator+MagicalAutoMigrations.h"
+#import "NSDictionary+MagicalRecordAdditions.h"
 
 @implementation AutoMigratingMagicalRecordStack
 
@@ -21,6 +22,13 @@
     [coordinator MR_addAutoMigratingSqliteStoreAtURL:self.storeURL withOptions:storeOptions];
     
     return coordinator;
+}
+
+- (NSDictionary *) defaultStoreOptions;
+{
+    NSMutableDictionary *options = [super defaultStoreOptions].mutableCopy;
+    [options addEntriesFromDictionary:[NSDictionary MR_autoMigrationOptions]];
+    return options;
 }
 
 @end

--- a/Library/MagicalRecordStack/AutoMigratingMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/AutoMigratingMagicalRecordStack.m
@@ -15,9 +15,11 @@
 - (NSPersistentStoreCoordinator *) createCoordinatorWithOptions:(NSDictionary *)options
 {
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self model]];
-
-    [coordinator MR_addAutoMigratingSqliteStoreAtURL:self.storeURL];
-
+    NSMutableDictionary *storeOptions = [options mutableCopy];
+    [storeOptions addEntriesFromDictionary:self.storeOptions];
+    
+    [coordinator MR_addAutoMigratingSqliteStoreAtURL:self.storeURL withOptions:storeOptions];
+    
     return coordinator;
 }
 

--- a/Library/MagicalRecordStack/SQLiteMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/SQLiteMagicalRecordStack.m
@@ -121,7 +121,7 @@
     MRLogVerbose(@"Loading Store at URL: %@", self.storeURL);
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self model]];
 
-    NSMutableDictionary *storeOptions = [[self defaultStoreOptions] mutableCopy];
+    NSMutableDictionary *storeOptions = [options mutableCopy];
     [storeOptions addEntriesFromDictionary:self.storeOptions];
     
     [coordinator MR_addSqliteStoreAtURL:self.storeURL withOptions:storeOptions];


### PR DESCRIPTION
SQLiteMagicalRecordStack didn't respect the options parameter in `- (NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(NSDictionary *)options`. AutoMigratingMagicalRecordStack didn't respect this parameter neither and additionally neglected the storeOptions property.
Store options should now be handled correctly. 