### PR TITLE
"Semantic Issues" in iOS project with MR as a pod

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -10,7 +10,9 @@
 #import "MagicalRecordLogging.h"
 #import <objc/runtime.h>
 
-@protocol MagicalRecord_DataImport
+@protocol MagicalDataImport
+
+@optional
 
 - (BOOL)shouldImport:(id)objectData;
 - (void)willImport:(id)objectData;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -1,4 +1,4 @@
-
+//
 //  Created by Saul Mora on 11/15/09.
 //  Copyright 2010 Magical Panda Software, LLC All rights reserved.
 //
@@ -7,6 +7,8 @@
 #import "MagicalRecordLogging.h"
 
 @protocol MagicalRecord
+
+@optional
 
 - (NSEntityDescription *)entityInManagedObjectContext:(NSManagedObjectContext *)context;
 - (NSEntityDescription *)insertInManagedObjectContext:(NSManagedObjectContext *)context;


### PR DESCRIPTION
In iOS project (SDK 8.1, deployment target 7.0, Xcode 6.1.1 6A2008a) with MagicalRecord as a pod multiple "Semantic Issues" appears on build. These issues are all about undeclared (invisible at the point where used) selectors. These selectors can be put in a protocol (not necessary exposed) to provide the compiler with their signatures.

What is suboptimal (hotfix) is MR_valueForUndefinedKey: in the protocol, because this selector is actually declared in NSDictionary+MagicalDataImport.m, but other approaches are much longer...

I see related issue: https://github.com/magicalpanda/MagicalRecord/issues/652 But it's closed and mention MR_SHORTHAND in discussion. If my approach to dealing with the issue is wrong, please let me know.
