### PR TITLE
Remove Usage Patterns from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ MagicalRecord was inspired by the ease of Ruby on Rails' Active Record fetching.
 - [Deleting Entities](Docs/Deleting-Entities.md)
 - [Fetching Entities](Docs/Fetching-Entities.md)
 - [Saving Entities](Docs/Saving-Entities.md)
-- [Usage Patterns](Docs/Usage-Patterns.md)
 - [Importing Data](Docs/Importing-Data.md)
 - [Logging](Docs/Logging.md)
 * [Other Resources](Docs/Other-Resources.md)


### PR DESCRIPTION
The file doesn't exist.