### PR TITLE
Add little precision about default entity creation context

### DIFF
--- a/Docs/Creating-Entities.md
+++ b/Docs/Creating-Entities.md
@@ -1,6 +1,6 @@
 # Creating Entities
 
-To create and insert a new instance of an Entity in the default context, you can use:
+To create and insert a new instance of an Entity in the current thread default context, you can use:
 
 ```objective-c
 Person *myPerson = [Person MR_createEntity];

--- a/Docs/Creating-Entities.md
+++ b/Docs/Creating-Entities.md
@@ -1,6 +1,6 @@
 # Creating Entities
 
-To create and insert a new instance of an Entity in the current thread default context, you can use:
+To create and insert a new instance of an Entity in the current thread's default context, you can use:
 
 ```objective-c
 Person *myPerson = [Person MR_createEntity];


### PR DESCRIPTION
After spending an hour trying to figure out why my entities weren't created in the default context as stated in the doc, I found in the code that it's in fact using contextForCurrentThread.

I hope this little precision will prevent people getting stuck as I did ;)

Devil is in the details !