### PR TITLE
Undefine LOG_LEVEL_DEF before setting a new log level

### DIFF
--- a/MagicalRecord/Core/MagicalRecordLogging.h
+++ b/MagicalRecord/Core/MagicalRecordLogging.h
@@ -23,6 +23,7 @@
 #endif
 
 #if __has_include("CocoaLumberjack.h")
+#undef LOG_LEVEL_DEF
 #define LOG_LEVEL_DEF (DDLogLevel)[MagicalRecord loggingLevel]
 #define CAST (DDLogFlag)
 #import <CocoaLumberjack/CocoaLumberjack.h>


### PR DESCRIPTION
I'm getting `Pods/Headers/Public/MagicalRecord/MagicalRecord/MagicalRecordLogging.h:26:9: 'LOG_LEVEL_DEF' macro redefined` warning while using CocoaLumberjack 2.0.0 & MagicalRecord.

While I don't entirely understand the logic of setting the log level, Undefining LOG_LEVEL_DEF before setting a new log level solves the compiler warning.

see https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Classes/CocoaLumberjack.h#L43 for more information 