### PR TITLE
added [NSPersistentStore MR_setApplicationStorageDirectory]

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.h
@@ -18,6 +18,7 @@ extern NSString * const kMagicalRecordDefaultStoreFileName;
 
 + (NSPersistentStore *) MR_defaultPersistentStore;
 + (void) MR_setDefaultPersistentStore:(NSPersistentStore *) store;
++ (void) MR_setApplicationStorageDirectory:(NSString *)urlString;
 
 + (NSURL *) MR_urlForStoreName:(NSString *)storeFileName;
 + (NSURL *) MR_cloudURLForUbiqutiousContainer:(NSString *)bucketName;

--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
@@ -10,6 +10,7 @@
 NSString * const kMagicalRecordDefaultStoreFileName = @"CoreDataStore.sqlite";
 
 static NSPersistentStore *defaultPersistentStore_ = nil;
+static NSString *applicationStorageDirectory_ = nil;
 
 
 @implementation NSPersistentStore (MagicalRecord)
@@ -24,20 +25,30 @@ static NSPersistentStore *defaultPersistentStore_ = nil;
 	defaultPersistentStore_ = store;
 }
 
++ (void) MR_setApplicationStorageDirectory:(NSString *)urlString {
+    applicationStorageDirectory_ = urlString;
+}
+
++ (NSString *) MR_defaultApplicationStorageDirectory {
+    NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
+    return [[self MR_directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];
+}
+
 + (NSString *) MR_directory:(NSSearchPathDirectory)type
 {    
     return [NSSearchPathForDirectoriesInDomains(type, NSUserDomainMask, YES) lastObject];
 }
 
-+ (NSString *)MR_applicationDocumentsDirectory 
-{
-	return [self MR_directory:NSDocumentDirectory];
-}
-
 + (NSString *)MR_applicationStorageDirectory
 {
-    NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString *)kCFBundleNameKey];
-    return [[self MR_directory:NSApplicationSupportDirectory] stringByAppendingPathComponent:applicationName];
+    // by default, MagicalRecord will use a directory in the that contains the bundle name,
+    // so changing the app bundle name will casue your core data store to reset
+    // to avoid this behaviour, use [NSPersistentStore MR_setApplicationStorageDirectory:] before setting up your stack
+    if (applicationStorageDirectory_ == nil) {
+        return [self MR_defaultApplicationStorageDirectory];
+    }
+  
+    return applicationStorageDirectory_;
 }
 
 + (NSURL *) MR_urlForStoreName:(NSString *)storeFileName

--- a/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStore+MagicalRecord.m
@@ -41,8 +41,8 @@ static NSString *applicationStorageDirectory_ = nil;
 
 + (NSString *)MR_applicationStorageDirectory
 {
-    // by default, MagicalRecord will use a directory in the that contains the bundle name,
-    // so changing the app bundle name will casue your core data store to reset
+    // by default, MagicalRecord uses a directory that contains the app bundle name from your plist,
+    // so changing the app bundle name will cause the core data persistent store to reset
     // to avoid this behaviour, use [NSPersistentStore MR_setApplicationStorageDirectory:] before setting up your stack
     if (applicationStorageDirectory_ == nil) {
         return [self MR_defaultApplicationStorageDirectory];


### PR DESCRIPTION
by default, MagicalRecord uses a directory that contains the app bundle name from the app's plist,

for example, `/Users/aporat/Library/Developer/CoreSimulator/Devices/D97EB168-ED1A-4726-A744-62E05B45C3FD/data/Containers/Data/Application/4C48F8A8-1CCD-4A72-AE6C-DBC8D6265568/Library/Application Support/Demo App For iOS`. this is highly problematic as changing the app bundle name will cause the core data persistent store to reset.

to avoid this behaviour, I've added [NSPersistentStore MR_setApplicationStorageDirectory:] to allow developers to choose a better directory for their core data stack

the default core data directory remains as is, so this addition doesn't break any existing code