### PR TITLE
Importing 'NSNull' for relationship sets value to 'nil'

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -182,7 +182,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         }
         @finally
         {
-            if (relatedObjectData == nil || [relatedObjectData isEqual:[NSNull null]])
+            if (relatedObjectData == nil)
             {
                 continue;
             }
@@ -200,6 +200,12 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
         if ([self MR_importValue:relationshipData forKey:relationshipName])
         {
             continue;
+        }
+      
+        if ([relatedObjectData isEqual:[NSNull null]])
+        {
+          [self setValue:nil forKey:lookupKey];
+          continue;
         }
 
         if ([relationshipInfo isToMany] && [relatedObjectData isKindOfClass:[NSArray class]])


### PR DESCRIPTION
If imported data does not include the key for a relationship, the relationship should be skipped. However, if the imported data does include the key with a value of `null` (`NSNull`), the relationship should still be imported, setting the value to `nil`.

In the event of a `null` value, the `shouldImportValue:` and `importValue:` selectors are called, passing the value `NSNull`, allowing the handling of a `null` value for a key to be overridden.