### PR TITLE
-- Transferred fix for Swift class name resolution from 2.0 to 3.0

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -14,20 +14,18 @@
 + (NSString *) MR_entityName;
 {
     NSString *entityName;
-
+    
     if ([self respondsToSelector:@selector(entityName)])
     {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wselector"
         entityName = [self performSelector:@selector(entityName)];
-#pragma clang diagnostic pop
     }
-
+    
     if ([entityName length] == 0)
     {
-        entityName = NSStringFromClass(self);
+        //swift prefixes classes, like ModuleName.MyClass and this causes problems with Core Data and NSSTringFromClass. We must handle that.
+        entityName = [NSStringFromClass(self) componentsSeparatedByString:@"."].lastObject;
     }
-
+    
     return entityName;
 }
 


### PR DESCRIPTION
This will allow MagicalRecord 3.0 to work with Swift again. This is essentially the same thing happened to version 2.0, some months ago.