### PR TITLE
userinfo `valueForKey:` to `objectForKey:`

### DIFF
--- a/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSAttributeDescription+MagicalDataImport.m
@@ -22,7 +22,7 @@
     id value = [objectData valueForKeyPath:keyPath];
     
     NSAttributeType attributeType = [self attributeType];
-    NSString *desiredAttributeType = [[self userInfo] valueForKey:kMagicalRecordImportAttributeValueClassNameKey];
+    NSString *desiredAttributeType = [[self userInfo] objectForKey:kMagicalRecordImportAttributeValueClassNameKey];
     if (desiredAttributeType) 
     {
         if ([desiredAttributeType hasSuffix:@"Color"])
@@ -36,7 +36,7 @@
         {
             if (![value isKindOfClass:[NSDate class]]) 
             {
-                NSString *dateFormat = [[self userInfo] valueForKey:kMagicalRecordImportCustomDateFormatKey];
+                NSString *dateFormat = [[self userInfo] objectForKey:kMagicalRecordImportCustomDateFormatKey];
                 if ([value isKindOfClass:[NSNumber class]]) {
                     value = MR_dateFromNumber(value, [dateFormat isEqualToString:kMagicalRecordImportUnixTimeString]);
                 }

--- a/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
@@ -15,7 +15,7 @@
 
 - (NSAttributeDescription *) MR_primaryAttributeToRelateBy;
 {
-    NSString *lookupKey = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([self name]);
+    NSString *lookupKey = [[self userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([self name]);
 
     return [self MR_attributeDescriptionForName:lookupKey];
 }

--- a/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSObject+MagicalDataImport.m
@@ -21,14 +21,14 @@ NSUInteger const kMagicalRecordImportMaximumAttributeFailoverDepth = 10;
 - (NSString *) MR_lookupKeyForAttribute:(NSAttributeDescription *)attributeInfo;
 {
     NSString *attributeName = [attributeInfo name];
-    NSString *lookupKey = [[attributeInfo userInfo] valueForKey:kMagicalRecordImportAttributeKeyMapKey] ?: attributeName;
+    NSString *lookupKey = [[attributeInfo userInfo] objectForKey:kMagicalRecordImportAttributeKeyMapKey] ?: attributeName;
     
     id value = [self valueForKeyPath:lookupKey];
     
     for (NSUInteger i = 1; i < kMagicalRecordImportMaximumAttributeFailoverDepth && value == nil; i++)
     {
         attributeName = [NSString stringWithFormat:@"%@.%lu", kMagicalRecordImportAttributeKeyMapKey, (unsigned long)i];
-        lookupKey = [[attributeInfo userInfo] valueForKey:attributeName];
+        lookupKey = [[attributeInfo userInfo] objectForKey:attributeName];
         if (lookupKey == nil) 
         {
             return nil;

--- a/MagicalRecord/Categories/DataImport/NSRelationshipDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSRelationshipDescription+MagicalDataImport.m
@@ -14,7 +14,7 @@
 
 - (NSString *) MR_primaryKey;
 {
-    NSString *primaryKeyName = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: 
+    NSString *primaryKeyName = [[self userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: 
     MR_primaryKeyNameFromString([[self destinationEntity] name]);
     
     return primaryKeyName;

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -172,7 +172,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
         NSRelationshipDescription *relationshipInfo = [relationships valueForKey:relationshipName];
 
-        NSString *lookupKey = [[relationshipInfo userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
+        NSString *lookupKey = [[relationshipInfo userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
 
         id relatedObjectData;
 
@@ -286,7 +286,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
                                   }
                                   else if (localObjectData)
                                   {
-                                      NSString *relatedByAttribute = [[relationshipInfo userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([[relationshipInfo destinationEntity] name]);
+                                      NSString *relatedByAttribute = [relationshipInfo MR_primaryKey];
 
                                       if (relatedByAttribute)
                                       {

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
@@ -44,7 +44,7 @@
     //verify mapping in relationship description userinfo
     NSEntityDescription *mappedEntity = [entity entity];
     NSRelationshipDescription *testRelationship = [[mappedEntity propertiesByName] valueForKey:@"mappedEntity"];
-    XCTAssertEqualObjects([[testRelationship userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey], @"someRandomAttributeName", @"Expected 'someRandomAttributeName' got '%@'", [[testRelationship userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey]);
+    XCTAssertEqualObjects([[testRelationship userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey], @"someRandomAttributeName", @"Expected 'someRandomAttributeName' got '%@'", [[testRelationship userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey]);
 
     NSNumber *numberOfEntities = [SingleEntityRelatedToMappedEntityUsingMappedPrimaryKey MR_numberOfEntities];
     XCTAssertEqualObjects(numberOfEntities, @1, @"Expected count of 1 entity, got %@", numberOfEntities);
@@ -70,7 +70,7 @@
     //verify mapping in relationship description userinfo
     NSEntityDescription *mappedEntity = [entity entity];
     NSRelationshipDescription *testRelationship = [[mappedEntity propertiesByName] valueForKey:@"mappedEntity"];
-    NSString *mapKey = [[testRelationship userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey];
+    NSString *mapKey = [[testRelationship userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey];
     XCTAssertEqualObjects(mapKey, @"someRandomAttributeName", @"Expected 'someRandomAttributeName' got '%@'", mapKey);
 
     NSNumber *entityCount = [SingleEntityRelatedToMappedEntityUsingMappedPrimaryKey MR_numberOfEntities];


### PR DESCRIPTION
userinfo is a dictionary: `objectForKey:` is faster and will prevent undesired behavior of `valueForKey:`

By undesired behavior, I mean when key is @"@class" or @"@copy" for instance.