### PR TITLE
userinfo `valueForKey:` to `objectForKey:`

### DIFF
--- a/Library/Categories/CoreData/Import/NSAttributeDescription+MagicalDataImport.m
+++ b/Library/Categories/CoreData/Import/NSAttributeDescription+MagicalDataImport.m
@@ -40,7 +40,7 @@
                 dateFormatKey = [dateFormatKey stringByAppendingFormat:@".%tu", index];
             }
             index++;
-            dateFormat = [[self userInfo] valueForKey:dateFormatKey];
+            dateFormat = [[self userInfo] objectForKey:dateFormatKey];
 
             convertedValue = [value MR_dateWithFormat:dateFormat];
 
@@ -105,7 +105,7 @@
 - (BOOL) MR_isColorAttributeType;
 {
     BOOL isColorAttributeType = NO;
-    NSString *desiredAttributeType = [[self userInfo] valueForKey:kMagicalRecordImportAttributeValueClassNameKey];
+    NSString *desiredAttributeType = [[self userInfo] objectForKey:kMagicalRecordImportAttributeValueClassNameKey];
     if (desiredAttributeType)
     {
         isColorAttributeType = [desiredAttributeType hasSuffix:@"Color"];

--- a/Library/Categories/CoreData/Import/NSEntityDescription+MagicalDataImport.m
+++ b/Library/Categories/CoreData/Import/NSEntityDescription+MagicalDataImport.m
@@ -39,14 +39,14 @@
 
 - (NSAttributeDescription *) MR_primaryAttributeToRelateBy;
 {
-    NSString *lookupKey = [[self userInfo] valueForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MRPrimaryKeyNameFromString([self name]);
+    NSString *lookupKey = [[self userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MRPrimaryKeyNameFromString([self name]);
 
     return [self MR_attributeDescriptionForName:lookupKey];
 }
 
 - (NSAttributeDescription *) MR_primaryAttribute;
 {
-    NSString *lookupKey = [[self userInfo] valueForKey:kMagicalRecordImportDistinctAttributeKey];
+    NSString *lookupKey = [[self userInfo] objectForKey:kMagicalRecordImportDistinctAttributeKey];
     return [self MR_attributeDescriptionForName:lookupKey];
 }
 

--- a/Library/Categories/CoreData/Import/NSObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/Import/NSObject+MagicalDataImport.m
@@ -25,7 +25,7 @@ NSUInteger const kMagicalRecordImportMaximumAttributeFailoverDepth = 10;
     for (NSUInteger i = 1; i < kMagicalRecordImportMaximumAttributeFailoverDepth && value == nil; i++)
     {
         attributeName = [NSString stringWithFormat:@"%@.%tu", kMagicalRecordImportAttributeKeyMapKey, i];
-        lookupKey = [userInfo valueForKey:attributeName];
+        lookupKey = [userInfo objectForKey:attributeName];
         if (lookupKey == nil) //stop after first nil key, means there are no more to look for
         {
             break;
@@ -33,7 +33,7 @@ NSUInteger const kMagicalRecordImportMaximumAttributeFailoverDepth = 10;
         value = [self valueForKeyPath:lookupKey];
     }
 
-    NSString *basicLookupKey = [userInfo valueForKey:kMagicalRecordImportAttributeKeyMapKey] ?: [propertyDescription name];
+    NSString *basicLookupKey = [userInfo objectForKey:kMagicalRecordImportAttributeKeyMapKey] ?: [propertyDescription name];
 
     return value != nil ? lookupKey : basicLookupKey;
 }

--- a/Library/Categories/CoreData/Import/NSRelationshipDescription+MagicalDataImport.m
+++ b/Library/Categories/CoreData/Import/NSRelationshipDescription+MagicalDataImport.m
@@ -15,7 +15,7 @@
 
 - (NSString *) MR_primaryKey;
 {
-    NSString *primaryKeyName = [[self userInfo] valueForKey:kMagicalRecordImportDistinctAttributeKey] ?: 
+    NSString *primaryKeyName = [[self userInfo] objectForKey:kMagicalRecordImportDistinctAttributeKey] ?: 
     MRPrimaryKeyNameFromString([[self destinationEntity] name]);
     
     return primaryKeyName;

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -119,7 +119,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 }
 - (void) MR_setAttribute:(NSAttributeDescription *)attributeInfo withValueFromObject:(id)objectData
 {
-    BOOL shouldExcludeFromImport = [[[attributeInfo userInfo] valueForKey:kMagicalRecordImportExcludeFromImportKey] isEqualToString:@"YES"];
+    BOOL shouldExcludeFromImport = [[[attributeInfo userInfo] objectForKey:kMagicalRecordImportExcludeFromImportKey] isEqualToString:@"YES"];
     if (shouldExcludeFromImport) {
         return;
     }
@@ -158,7 +158,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
     if ([self MR_importValue:relationshipData forKey:relationshipName]) return; //If custom import was used
 
-    NSString *lookupKey = [[relationshipInfo userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
+    NSString *lookupKey = [[relationshipInfo userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey] ?: relationshipName;
     id relatedObjectData = [relationshipData valueForKeyPath:lookupKey];
     if (relatedObjectData == nil)
     {

--- a/Library/Categories/Foundation/NSError+MagicalRecordErrorHandling.m
+++ b/Library/Categories/Foundation/NSError+MagicalRecordErrorHandling.m
@@ -46,7 +46,7 @@ NSString *MR_errorSummaryFromErrorCode(NSInteger errorCode)
 
 - (NSArray *) MR_errorCollection;
 {
-    return [self code] == NSValidationMultipleErrorsError ? [[self userInfo] valueForKey:NSDetailedErrorsKey] : @[self];
+    return [self code] == NSValidationMultipleErrorsError ? [[self userInfo] objectForKey:NSDetailedErrorsKey] : @[self];
 }
 
 - (NSDictionary *) MR_errorCollectionGroupedByObject;
@@ -80,9 +80,9 @@ NSString *MR_errorSummaryFromErrorCode(NSInteger errorCode)
     }
     else if (errorCode == NSManagedObjectMergeError)
     {
-        return [[self userInfo] valueForKey:@"conflictList"];
+        return [[self userInfo] objectForKey:@"conflictList"];
     }
-    return [NSString stringWithFormat:@"(%zd) %@ [%@]", errorCode, MR_errorSummaryFromErrorCode(errorCode), [self MR_validationErrorObject] ?: [[self userInfo] valueForKey:@"reason"]];
+    return [NSString stringWithFormat:@"(%zd) %@ [%@]", errorCode, MR_errorSummaryFromErrorCode(errorCode), [self MR_validationErrorObject] ?: [[self userInfo] objectForKey:@"reason"]];
 }
 
 - (NSString *) MR_coreDataDescription;
@@ -116,7 +116,7 @@ NSString *MR_errorSummaryFromErrorCode(NSInteger errorCode)
 
 - (id) MR_validationError;
 {
-    return [[self userInfo] valueForKey:NSValidationKeyErrorKey];
+    return [[self userInfo] objectForKey:NSValidationKeyErrorKey];
 }
 
 - (NSManagedObject *) MR_validationErrorObject;

--- a/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
+++ b/Tests/DataImport/ImportSingleEntityRelatedToMappedEntityUsingMappedPrimaryKeyTests.m
@@ -27,7 +27,7 @@
     // Verify mapping in relationship description userinfo
     NSEntityDescription *mappedEntity = [entity entity];
     NSRelationshipDescription *testRelationship = [[mappedEntity propertiesByName] valueForKey:@"mappedEntity"];
-    expect([[testRelationship userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey]).to.equal(@"someRandomAttributeName");
+    expect([[testRelationship userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey]).to.equal(@"someRandomAttributeName");
 }
 
 - (void)testImportMappedEntityUsingPrimaryRelationshipKey
@@ -45,7 +45,7 @@
     // Verify mapping in relationship description userinfo
     NSEntityDescription *mappedEntity = [entity entity];
     NSRelationshipDescription *testRelationship = [[mappedEntity propertiesByName] valueForKey:@"mappedEntity"];
-    expect([[testRelationship userInfo] valueForKey:kMagicalRecordImportRelationshipMapKey]).to.equal(@"someRandomAttributeName");
+    expect([[testRelationship userInfo] objectForKey:kMagicalRecordImportRelationshipMapKey]).to.equal(@"someRandomAttributeName");
 }
 
 @end


### PR DESCRIPTION
userinfo is a dictionary: `objectForKey:` is faster and will prevent undesired behavior of `valueForKey:`

By undesired behavior, I mean when key is @"@class" or @"@copy" for instance.