### PR TITLE
fix podspec for Cocoapods 0.39 compatibility with '~> 2.2.0'

### DIFF
--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.2' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.platform = :ios
-  s.platform = :osx
+  s.ios.deployment_target = ""
+  s.osx.deployment_target = ""
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true

--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -1,20 +1,17 @@
 Pod::Spec.new do |s|
   s.name     = 'MagicalRecord'
-  s.version  = '2.1.0'
+  s.version  = '2.2.0'
   s.license  = 'MIT'
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.1' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.2' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
+  s.platform = :ios
+  s.platform = :osx
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
 
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
+  s.prefix_header_contents = "#ifdef __OBJC__\n#define MR_SHORTHAND\n#import \"CoreData+MagicalRecord.h\"\n#endif"
 end


### PR DESCRIPTION
Completion of the fix will also require:
    pod trunk --allow-warnings push MagicalRecord.podspec 

This fixes https://github.com/magicalpanda/MagicalRecord/issues/1087