### PR TITLE
relatedByAttribute key was being ignored

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -281,10 +281,15 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
     {
         NSManagedObjectContext *context = [self managedObjectContext];
         Class managedObjectClass = NSClassFromString([destinationEntity managedObjectClassName]);
-        NSString *primaryKey = [[destinationEntity MR_primaryAttribute] name];
-        if ([primaryKey length])
+				NSString *relatedByAtribute = [relationshipInfo.userInfo objectForKey:kMagicalRecordImportRelationshipLinkedByKey];
+
+				if (relatedByAtribute == nil || [relatedByAtribute length] == 0) {
+            relatedByAtribute = [[destinationEntity MR_primaryAttribute] name];
+        }       
+				
+        if ([relatedByAtribute length])
         {
-            objectForRelationship = [managedObjectClass MR_findFirstByAttribute:primaryKey
+            objectForRelationship = [managedObjectClass MR_findFirstByAttribute:relatedByAtribute
                                                                       withValue:relatedValue
                                                                       inContext:context];
         }


### PR DESCRIPTION
When setting the relationship in an import, then relatedByAttribute was being ignored. I changed it to use the primary key as the fallback.