### PR TITLE
Enable warnings for implicit nullability conversions

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalAggregation.h
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalAggregation.h
@@ -84,11 +84,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)MR_hasAtLeastOneEntityInContext:(NSManagedObjectContext *)context;
 
-- (id)MR_minValueFor:(NSString *)property;
-- (id)MR_maxValueFor:(NSString *)property;
+- (nullable id)MR_minValueFor:(nonnull NSString *)property;
+- (nullable id)MR_maxValueFor:(nonnull NSString *)property;
 
-+ (id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
-+ (id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
++ (nullable id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate;
++ (nullable id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 
 /**
  Supports aggregating values using a key-value collection operator that can be grouped by an attribute.
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSArray *)MR_aggregateOperation:(NSString *)collectionOperator onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate groupBy:(NSString *)groupingKeyPath;
 
-- (id)MR_objectWithMinValueFor:(NSString *)property;
+- (nullable id)MR_objectWithMinValueFor:(nonnull NSString *)property;
 - (id)MR_objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context;
 
 @end

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalAggregation.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalAggregation.m
@@ -84,18 +84,14 @@
 
 - (id)MR_minValueFor:(NSString *)property
 {
-    NSManagedObject *obj = [[self class] MR_findFirstByAttribute:property
-                                                       withValue:[NSString stringWithFormat:@"min(%@)", property]];
-
-    return [obj valueForKey:property];
+    NSManagedObject *obj = [[self class] MR_findFirstByAttribute:property withValue:[NSString stringWithFormat:@"min(%@)", property]];
+    return (obj != nil) ? [obj valueForKey:property] : nil;
 }
 
 - (id)MR_maxValueFor:(NSString *)property
 {
-    NSManagedObject *obj = [[self class] MR_findFirstByAttribute:property
-                                                       withValue:[NSString stringWithFormat:@"max(%@)", property]];
-
-    return [obj valueForKey:property];
+    NSManagedObject *obj = [[self class] MR_findFirstByAttribute:property withValue:[NSString stringWithFormat:@"max(%@)", property]];
+    return (obj != nil) ? [obj valueForKey:property] : nil;
 }
 
 - (id)MR_objectWithMinValueFor:(NSString *)property inContext:(NSManagedObjectContext *)context
@@ -110,7 +106,8 @@
 
 - (id)MR_objectWithMinValueFor:(NSString *)property
 {
-    return [self MR_objectWithMinValueFor:property inContext:[self managedObjectContext]];
+    NSManagedObjectContext *context = self.managedObjectContext;
+    return (context != nil) ? [self MR_objectWithMinValueFor:property inContext:context] : nil;
 }
 
 + (id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context
@@ -132,8 +129,7 @@
     [request setResultType:NSDictionaryResultType];
 
     NSDictionary *resultsDictionary = [self MR_executeFetchRequestAndReturnFirstObject:request inContext:context];
-
-    return [resultsDictionary objectForKey:@"result"];
+    return (resultsDictionary != nil) ? [resultsDictionary objectForKey:@"result"] : nil;
 }
 
 + (id)MR_aggregateOperation:(NSString *)function onAttribute:(NSString *)attributeName withPredicate:(NSPredicate *)predicate

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFinders.h
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFinders.h
@@ -61,10 +61,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (id)MR_findSmallestValueForAttribute:(NSString *)attribute;
 + (id)MR_findSmallestValueForAttribute:(NSString *)attribute inContext:(NSManagedObjectContext *)context;
 
-+ (id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending;
-+ (id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
-+ (id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending withPredicate:(NSPredicate *)predicate;
-+ (id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
++ (nullable id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending;
++ (nullable id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (nullable id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending withPredicate:(NSPredicate *)predicate;
++ (nullable id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending withPredicate:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
 
 + (NSArray *)MR_findByAttribute:(NSString *)attribute withValue:(id)searchValue;
 + (NSArray *)MR_findByAttribute:(NSString *)attribute withValue:(id)searchValue inContext:(NSManagedObjectContext *)context;

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFinders.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFinders.m
@@ -81,7 +81,7 @@
     [request setPropertiesToFetch:[NSArray arrayWithObject:attribute]];
     NSArray *results = [self MR_executeFetchRequest:request inContext:context];
 
-    return [results valueForKeyPath:[NSString stringWithFormat:@"@unionOfObjects.%@", attribute]];
+    return (results != nil) ? [results valueForKeyPath:[NSString stringWithFormat:@"@unionOfObjects.%@", attribute]] : nil;
 }
 
 + (id)MR_selectAttribute:(NSString *)attribute ascending:(BOOL)ascending withPredicate:(NSPredicate *)predicate
@@ -96,7 +96,7 @@
     [request setPropertiesToFetch:[NSArray arrayWithObject:attribute]];
     NSArray *results = [self MR_executeFetchRequest:request inContext:context];
 
-    return [results valueForKeyPath:[NSString stringWithFormat:@"@unionOfObjects.%@", attribute]];
+    return (results != nil) ? [results valueForKeyPath:[NSString stringWithFormat:@"@unionOfObjects.%@", attribute]] : nil;
 }
 
 + (instancetype)MR_findFirst

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -39,8 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSString *)MR_entityName;
 
-+ (NSEntityDescription *)MR_entityDescription;
-+ (NSEntityDescription *)MR_entityDescriptionInContext:(NSManagedObjectContext *)context;
++ (nullable NSEntityDescription *)MR_entityDescription;
++ (nullable NSEntityDescription *)MR_entityDescriptionInContext:(NSManagedObjectContext *)context;
 
 + (NSArray *)MR_propertiesNamed:(NSArray *)properties;
 + (NSArray *)MR_propertiesNamed:(NSArray *)properties inContext:(NSManagedObjectContext *)context;

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -166,7 +166,8 @@
 
 - (BOOL)MR_deleteEntity
 {
-    return [self MR_deleteEntityInContext:[self managedObjectContext]];
+    NSManagedObjectContext *context = self.managedObjectContext;
+    return (context != nil) ? [self MR_deleteEntityInContext:context] : NO;
 }
 
 - (BOOL)MR_deleteEntityInContext:(NSManagedObjectContext *)context

--- a/Library/Categories/CoreData/NSManagedObjectModel+MagicalRecord.h
+++ b/Library/Categories/CoreData/NSManagedObjectModel+MagicalRecord.h
@@ -1,19 +1,13 @@
 //
-//  NSManagedObjectModel+MagicalRecord.h
-//
-//  Created by Saul Mora on 3/11/10.
 //  Copyright 2010 Magical Panda Software, LLC All rights reserved.
-//
 
 @import CoreData;
 
-NS_ASSUME_NONNULL_BEGIN
 @interface NSManagedObjectModel (MagicalRecord)
 
-+ (NSManagedObjectModel *)MR_managedObjectModelAtURL:(NSURL *)url;
-+ (NSManagedObjectModel *)MR_mergedObjectModelFromMainBundle;
-+ (NSManagedObjectModel *)MR_managedObjectModelNamed:(NSString *)modelFileName;
-+ (NSManagedObjectModel *)MR_newModelNamed:(NSString *)modelName inBundleNamed:(NSString *)bundleName NS_RETURNS_RETAINED;
++ (nullable NSManagedObjectModel *)MR_managedObjectModelAtURL:(nonnull NSURL *)url;
++ (nullable NSManagedObjectModel *)MR_mergedObjectModelFromMainBundle;
++ (nonnull NSManagedObjectModel *)MR_managedObjectModelNamed:(nonnull NSString *)modelFileName;
++ (nonnull NSManagedObjectModel *)MR_newModelNamed:(nonnull NSString *)modelName inBundleNamed:(nonnull NSString *)bundleName NS_RETURNS_RETAINED;
 
 @end
-NS_ASSUME_NONNULL_END

--- a/Library/Categories/CoreData/NSManagedObjectModel+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObjectModel+MagicalRecord.m
@@ -1,29 +1,23 @@
 //
-//  NSManagedObjectModel+MagicalRecord.m
-//
-//  Created by Saul Mora on 3/11/10.
 //  Copyright 2010 Magical Panda Software, LLC All rights reserved.
-//
 
 #import "NSManagedObjectModel+MagicalRecord.h"
 
 @implementation NSManagedObjectModel (MagicalRecord)
 
-+ (NSManagedObjectModel *)MR_managedObjectModelAtURL:(NSURL *)url
++ (nullable NSManagedObjectModel *)MR_managedObjectModelAtURL:(nonnull NSURL *)url
 {
     return [[NSManagedObjectModel alloc] initWithContentsOfURL:url];
 }
 
-+ (NSManagedObjectModel *)MR_mergedObjectModelFromMainBundle
++ (nullable NSManagedObjectModel *)MR_mergedObjectModelFromMainBundle
 {
     return [self mergedModelFromBundles:nil];
 }
 
-+ (NSManagedObjectModel *)MR_newModelNamed:(NSString *)modelName inBundleNamed:(NSString *)bundleName
++ (nonnull NSManagedObjectModel *)MR_newModelNamed:(nonnull NSString *)modelName inBundleNamed:(nonnull NSString *)bundleName
 {
-    NSString *path = [[NSBundle mainBundle] pathForResource:[modelName stringByDeletingPathExtension]
-                                                     ofType:[modelName pathExtension]
-                                                inDirectory:bundleName];
+    NSString *path = [[NSBundle mainBundle] pathForResource:[modelName stringByDeletingPathExtension] ofType:[modelName pathExtension] inDirectory:bundleName];
     NSURL *modelUrl = [NSURL fileURLWithPath:path];
 
     NSManagedObjectModel *mom = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelUrl];
@@ -31,10 +25,9 @@
     return mom;
 }
 
-+ (NSManagedObjectModel *)MR_managedObjectModelNamed:(NSString *)modelFileName
++ (nonnull NSManagedObjectModel *)MR_managedObjectModelNamed:(nonnull NSString *)modelFileName
 {
-    NSString *path = [[NSBundle mainBundle] pathForResource:[modelFileName stringByDeletingPathExtension]
-                                                     ofType:[modelFileName pathExtension]];
+    NSString *path = [[NSBundle mainBundle] pathForResource:[modelFileName stringByDeletingPathExtension] ofType:[modelFileName pathExtension]];
     NSURL *momURL = [NSURL fileURLWithPath:path];
 
     NSManagedObjectModel *model = [[NSManagedObjectModel alloc] initWithContentsOfURL:momURL];

--- a/Library/Categories/CoreData/NSPersistentStore+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSPersistentStore+MagicalRecord.m
@@ -89,7 +89,8 @@
     for (NSURL *storeUrl in storeUrls)
     {
         NSURL *copyToURL = [destinationUrl URLByDeletingPathExtension];
-        copyToURL = [copyToURL URLByAppendingPathExtension:[storeUrl pathExtension]];
+        NSString *pathExtension = storeUrl.pathExtension;
+        copyToURL = [copyToURL URLByAppendingPathExtension:pathExtension];
         success &= [fileManager copyItemAtURL:storeUrl toURL:copyToURL error:error];
     }
     return success;
@@ -129,7 +130,8 @@
 
 - (BOOL)MR_removePersistentStoreFiles
 {
-    return [[self class] MR_removePersistentStoreFilesAtURL:self.URL];
+    NSURL *storeURL = self.URL;
+    return (storeURL != nil) ? [[self class] MR_removePersistentStoreFilesAtURL:storeURL] : NO;
 }
 
 + (BOOL)MR_removePersistentStoreFilesAtURL:(NSURL *)url

--- a/Library/Categories/CoreData/NSPersistentStoreCoordinator/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSPersistentStoreCoordinator/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -16,10 +16,10 @@ NSString *const MagicalRecordShouldDeletePersistentStoreOnModelMismatchKey = @"M
 + (void)MR_createPathToStoreFileIfNeccessary:(NSURL *)urlForStore
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSURL *pathToStore = [urlForStore URLByDeletingLastPathComponent];
+    NSString *pathToStore = urlForStore.URLByDeletingLastPathComponent.path;
 
     NSError *error = nil;
-    BOOL pathWasCreated = [fileManager createDirectoryAtPath:[pathToStore path] withIntermediateDirectories:YES attributes:nil error:&error];
+    BOOL pathWasCreated = (pathToStore != nil) ? [fileManager createDirectoryAtPath:pathToStore withIntermediateDirectories:YES attributes:nil error:&error] : NO;
 
     if (!pathWasCreated)
     {
@@ -122,7 +122,11 @@ NSString *const MagicalRecordShouldDeletePersistentStoreOnModelMismatchKey = @"M
 {
     NSPersistentStoreCoordinator *psc = [[self alloc] initWithManagedObjectModel:model];
 
-    [psc MR_addSqliteStoreNamed:[persistentStore URL] withOptions:options];
+    NSURL *pscURL = persistentStore.URL;
+    if (pscURL != nil)
+    {
+        [psc MR_addSqliteStoreNamed:pscURL withOptions:options];
+    }
 
     return psc;
 }

--- a/Library/MagicalMigrationManager.h
+++ b/Library/MagicalMigrationManager.h
@@ -1,22 +1,17 @@
 //
-//  MagicalMigrationManager.h
-//  Photobucket Next
-//
-//  Created by Saul Mora on 8/6/13.
-//  Copyright (c) 2013 Photobucket. All rights reserved.
-//
+//  Copyright © 2013 Magical Panda Software, LLC. All rights reserved.
 
 @import Foundation;
 
 @interface MagicalMigrationManager : NSObject
 
-@property (nonatomic, copy) NSString *sourceModelName;
-@property (nonatomic, copy) NSString *targetModelName;
-@property (nonatomic, copy) NSString *versionedModelName;
+@property (readwrite, nonnull, nonatomic, copy) NSString *sourceModelName;
+@property (readwrite, nonnull, nonatomic, copy) NSString *targetModelName;
+@property (readwrite, nonnull, nonatomic, copy) NSString *versionedModelName;
 
-- (instancetype)initWithSourceModelName:(NSString *)sourceName targetModelName:(NSString *)targetName;
+- (nonnull instancetype)initWithSourceModelName:(nonnull NSString *)sourceName targetModelName:(nonnull NSString *)targetName;
 
-- (BOOL)migrateStoreAtURL:(NSURL *)sourceStoreURL toStoreAtURL:(NSURL *)targetStoreURL;
-- (BOOL)migrateStoreAtURL:(NSURL *)sourceStoreURL toStoreAtURL:(NSURL *)targetStoreURL mappingModelURL:(NSURL *)mappingModelURL;
+- (BOOL)migrateStoreAtURL:(nonnull NSURL *)sourceStoreURL toStoreAtURL:(nonnull NSURL *)targetStoreURL;
+- (BOOL)migrateStoreAtURL:(nonnull NSURL *)sourceStoreURL toStoreAtURL:(nonnull NSURL *)targetStoreURL mappingModelURL:(nullable NSURL *)mappingModelURL;
 
 @end

--- a/Library/MagicalMigrationManager.m
+++ b/Library/MagicalMigrationManager.m
@@ -1,10 +1,5 @@
 //
-//  MagicalMigrationManager.m
-//  Photobucket Next
-//
-//  Created by Saul Mora on 8/6/13.
-//  Copyright (c) 2013 Photobucket. All rights reserved.
-//
+//  Copyright © 2013 Magical Panda Software, LLC. All rights reserved.
 
 #import "MagicalMigrationManager.h"
 @import CoreData;
@@ -243,26 +238,29 @@
 {
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];
     NSString *backupPath = [NSTemporaryDirectory() stringByAppendingPathComponent:guid];
-
+    
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    if (![fileManager moveItemAtPath:sourceStoreURL.path
-                              toPath:backupPath
-                               error:error])
+    NSString *sourceStorePath = sourceStoreURL.path;
+
+    if (sourceStorePath == nil ||
+        NO == [fileManager moveItemAtPath:sourceStorePath toPath:backupPath error:error])
     {
         // Failed to copy the file
         return NO;
     }
+
+    NSString *destinationStorePath = destinationStoreURL.path;
+
     // Move the destination to the source path
-    if (![fileManager moveItemAtPath:destinationStoreURL.path
-                              toPath:sourceStoreURL.path
-                               error:error])
+    if (destinationStorePath == nil ||
+        NO == [fileManager moveItemAtPath:destinationStorePath toPath:sourceStorePath error:error])
     {
         // Try to back out the source move first, no point in checking it for errors
-        [fileManager moveItemAtPath:backupPath
-                             toPath:sourceStoreURL.path
-                              error:nil];
+        [fileManager moveItemAtPath:backupPath toPath:sourceStorePath error:nil];
+
         return NO;
     }
+
     return YES;
 }
 

--- a/Library/MagicalRecordStack/MagicalRecordStack+Private.h
+++ b/Library/MagicalRecordStack/MagicalRecordStack+Private.h
@@ -1,19 +1,14 @@
 //
-//  MagicalRecordStack_Private.h
-//  MagicalRecord
-//
-//  Created by Saul Mora on 9/15/13.
-//  Copyright (c) 2013 Magical Panda Software LLC. All rights reserved.
-//
+//  Copyright © 2013 Magical Panda Software LLC. All rights reserved.
 
 #import "MagicalRecordStack.h"
 
 @interface MagicalRecordStack ()
 
-- (NSPersistentStoreCoordinator *)createCoordinator;
-- (NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(NSDictionary *)options;
+- (nonnull NSPersistentStoreCoordinator *)createCoordinator;
+- (nonnull NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(nullable NSDictionary *)options;
 
-- (NSManagedObjectContext *)createConfinementContext;
+- (nonnull NSManagedObjectContext *)createConfinementContext;
 - (void)loadStack;
 
 @end

--- a/Library/MagicalRecordStack/MagicalRecordStack.h
+++ b/Library/MagicalRecordStack/MagicalRecordStack.h
@@ -1,39 +1,32 @@
 //
-//  MagicalRecordStack.h
-//  MagicalRecord
-//
-//  Created by Saul Mora on 9/14/13.
-//  Copyright (c) 2013 Magical Panda Software LLC. All rights reserved.
-//
+//  Copyright © 2013 Magical Panda Software LLC. All rights reserved.
 
 @import Foundation;
 @import CoreData;
 
-NS_ASSUME_NONNULL_BEGIN
 @interface MagicalRecordStack : NSObject
 
-@property (nonatomic, copy) NSString *stackName;
+@property (readwrite, nonnull, nonatomic, copy) NSString *stackName;
 
-@property (nonatomic, strong) NSManagedObjectContext *context;
-@property (nonatomic, strong) NSManagedObjectModel *model;
-@property (nonatomic, strong) NSPersistentStoreCoordinator *coordinator;
-@property (nonatomic, strong) NSPersistentStore *store;
+@property (readwrite, nonnull, nonatomic, strong) NSManagedObjectContext *context;
+@property (readwrite, nonnull, nonatomic, strong) NSManagedObjectModel *model;
+@property (readwrite, nonnull, nonatomic, strong) NSPersistentStoreCoordinator *coordinator;
+@property (readwrite, nullable, nonatomic, strong) NSPersistentStore *store;
 
-@property (nonatomic, assign) BOOL loggingEnabled;
-@property (nonatomic, assign) BOOL saveOnApplicationWillTerminate;
-@property (nonatomic, assign) BOOL saveOnApplicationWillResignActive;
+@property (readwrite, nonatomic, assign) BOOL loggingEnabled;
+@property (readwrite, nonatomic, assign) BOOL saveOnApplicationWillTerminate;
+@property (readwrite, nonatomic, assign) BOOL saveOnApplicationWillResignActive;
 
-+ (__nullable instancetype)defaultStack;
-+ (void)setDefaultStack:(MagicalRecordStack *__nullable)stack;
++ (nonnull instancetype)defaultStack;
++ (void)setDefaultStack:(nullable MagicalRecordStack *)stack;
 
-+ (instancetype)stack;
++ (nonnull instancetype)stack;
 
 - (void)reset;
 
-- (NSManagedObjectContext *)newConfinementContext;
+- (nonnull NSManagedObjectContext *)newConfinementContext;
 
-- (void)setModelFromClass:(Class)modelClass;
-- (void)setModelNamed:(NSString *)modelName;
+- (void)setModelFromClass:(nonnull Class)modelClass;
+- (void)setModelNamed:(nonnull NSString *)modelName;
 
 @end
-NS_ASSUME_NONNULL_END

--- a/Library/MagicalRecordStack/MagicalRecordStack.m
+++ b/Library/MagicalRecordStack/MagicalRecordStack.m
@@ -1,10 +1,5 @@
 //
-//  MagicalRecordStack.m
-//  MagicalRecord
-//
-//  Created by Saul Mora on 9/14/13.
-//  Copyright (c) 2013 Magical Panda Software LLC. All rights reserved.
-//
+//  Copyright © 2013 Magical Panda Software LLC. All rights reserved.
 
 #import "MagicalRecordStack.h"
 
@@ -97,7 +92,7 @@ static MagicalRecordStack *defaultStack;
     _store = nil;
 }
 
-- (NSManagedObjectContext *)context
+- (nonnull NSManagedObjectContext *)context
 {
     if (_context == nil)
     {
@@ -109,7 +104,7 @@ static MagicalRecordStack *defaultStack;
     return _context;
 }
 
-- (NSString *)stackName
+- (nonnull NSString *)stackName
 {
     if (_stackName == nil)
     {
@@ -134,11 +129,13 @@ static MagicalRecordStack *defaultStack;
     return context;
 }
 
-- (NSManagedObjectModel *)model
+- (nonnull NSManagedObjectModel *)model
 {
     if (_model == nil)
     {
-        _model = [NSManagedObjectModel MR_mergedObjectModelFromMainBundle];
+        NSManagedObjectModel *model = [NSManagedObjectModel MR_mergedObjectModelFromMainBundle];
+        NSParameterAssert(model != nil);
+        _model = model;
     }
     return _model;
 }
@@ -148,7 +145,7 @@ static MagicalRecordStack *defaultStack;
     if (_coordinator == nil)
     {
         _coordinator = [self createCoordinator];
-        _store = [[_coordinator persistentStores] lastObject];
+        _store = _coordinator.persistentStores.firstObject;
     }
     return _coordinator;
 }

--- a/MagicalRecord.xcodeproj/project.pbxproj
+++ b/MagicalRecord.xcodeproj/project.pbxproj
@@ -1730,7 +1730,6 @@
 					"-Wno-pedantic",
 					"-Wno-direct-ivar-access",
 					"-Wno-cast-qual",
-					"-Wno-nullable-to-nonnull-conversion",
 					"-Wno-reserved-id-macro",
 					"-Wno-auto-import",
 				);
@@ -1812,7 +1811,6 @@
 					"-Wno-pedantic",
 					"-Wno-direct-ivar-access",
 					"-Wno-cast-qual",
-					"-Wno-nullable-to-nonnull-conversion",
 					"-Wno-reserved-id-macro",
 					"-Wno-auto-import",
 				);

--- a/Tests/Core/MagicalRecordStackTests.m
+++ b/Tests/Core/MagicalRecordStackTests.m
@@ -39,7 +39,10 @@
     NSURL *testStoreURL = [NSPersistentStore MR_fileURLForStoreName:[MagicalRecord defaultStoreName]];
     XCTAssertNotNil(testStoreURL);
 
-    [[NSFileManager defaultManager] removeItemAtPath:[testStoreURL path] error:nil];
+    NSString *testStorePath = testStoreURL.path;
+    XCTAssertNotNil(testStorePath);
+
+    [[NSFileManager defaultManager] removeItemAtPath:testStorePath error:nil];
 
     MagicalRecordStack *defaultStack = [SQLiteMagicalRecordStack stackWithStoreAtURL:testStoreURL];
     [defaultStack setModelFromClass:[self class]];
@@ -69,8 +72,10 @@
     NSString *testStoreName = @"MyTestDataStore.sqlite";
 
     NSURL *testStoreURL = [NSPersistentStore MR_fileURLForStoreName:testStoreName];
+    NSString *testStorePath = testStoreURL.path;
+    XCTAssertNotNil(testStorePath);
 
-    [[NSFileManager defaultManager] removeItemAtPath:[testStoreURL path] error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:testStorePath error:nil];
 
     MagicalRecordStack *defaultStack = [SQLiteMagicalRecordStack stackWithStoreNamed:testStoreName];
     [MagicalRecordStack setDefaultStack:defaultStack];

--- a/Tests/Core/NSPersistentStoreCoordinator+MagicalRecordTests.m
+++ b/Tests/Core/NSPersistentStoreCoordinator+MagicalRecordTests.m
@@ -1,7 +1,5 @@
 //
-//  Created by Tony Arnold on 25/03/2014.
 //  Copyright (c) 2014 Magical Panda Software LLC. All rights reserved.
-//
 
 #import "MagicalRecordTestBase.h"
 
@@ -18,10 +16,11 @@
     [super setUp];
 
     NSURL *testStoreURL = [NSPersistentStore MR_fileURLForStoreNameIfExistsOnDisk:@"TestStore.sqlite"];
+    NSString *testStorePath = testStoreURL.path;
 
-    if (testStoreURL)
+    if (testStoreURL != nil && testStorePath != nil)
     {
-        [[NSFileManager defaultManager] removeItemAtPath:[testStoreURL path] error:nil];
+        [[NSFileManager defaultManager] removeItemAtPath:testStorePath error:nil];
     }
 
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];


### PR DESCRIPTION
Also resolves any existing issues that Xcode reported. This is not complete nullability annotation for the project, just the essentials

Enabling this warning will force all code to explicitly handle situations where a return value may be nil, but the API expects a non-nil value.