### PR TITLE
Add error logging when value for relatedByAttribute is invalid

### DIFF
--- a/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
@@ -16,8 +16,18 @@
 - (NSAttributeDescription *) MR_primaryAttributeToRelateBy;
 {
     NSString *lookupKey = [[self userInfo] objectForKey:kMagicalRecordImportRelationshipLinkedByKey] ?: MR_primaryKeyNameFromString([self name]);
-
-    return [self MR_attributeDescriptionForName:lookupKey];
+    NSAttributeDescription *attributeDescription = [self MR_attributeDescriptionForName:lookupKey];
+    
+    if(attributeDescription == nil) {
+        MRLogError(
+                   @"Invalid value for key '%@' in '%@' entity. Remove this key or add attribute '%@'\n",
+                   kMagicalRecordImportRelationshipLinkedByKey,
+                   self.name,
+                   lookupKey
+                   );
+    }
+    
+    return attributeDescription;
 }
 
 - (NSManagedObject *) MR_createInstanceInContext:(NSManagedObjectContext *)context;

--- a/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
+++ b/MagicalRecord/Categories/DataImport/NSEntityDescription+MagicalDataImport.m
@@ -10,6 +10,7 @@
 #import "NSManagedObject+MagicalDataImport.h"
 #import "NSManagedObject+MagicalRecord.h"
 #import "MagicalImportFunctions.h"
+#import "MagicalRecordLogging.h"
 
 @implementation NSEntityDescription (MagicalRecord_DataImport)
 


### PR DESCRIPTION
This will log an error if the value of an entity's `relatedByAttribute` is not valid when calling `MR_importFromObject:`, `MR_importFromObject:inContext:`, `MR_importFromArray:`, and `MR_importFromArray:inContext:`.  Note, however, that this does not catch or handle any errors; the app will still crash.