### PR TITLE
Fixes crash when importing object with no 'primaryAttribute' in Swift

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -297,11 +297,10 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 {
     NSAttributeDescription *primaryAttribute = [[self MR_entityDescriptionInContext:context] MR_primaryAttributeToRelateBy];
     
-    id value = [objectData MR_valueForAttribute:primaryAttribute];
-    
     NSManagedObject *managedObject = nil;
     if (primaryAttribute != nil)
     {
+      id value = [objectData MR_valueForAttribute:primaryAttribute];
         managedObject = [self MR_findFirstByAttribute:[primaryAttribute name] withValue:value inContext:context];
     }
     if (managedObject == nil)


### PR DESCRIPTION
Magical Record 2.x is causing a crash when trying to bridge a nil `primaryAttribute` to Objective-C.

This prevents the crash with no functional changes to the library.

See for more info:
http://stackoverflow.com/questions/32514819/mr-importfromobject-method-is-not-working-in-xcode7-1-beta-swift-2-0