### PR TITLE
Fixed 'LOG_MAYBE macro redefined' warning 

### DIFF
--- a/MagicalRecord/Core/MagicalRecordLogging.h
+++ b/MagicalRecord/Core/MagicalRecordLogging.h
@@ -22,7 +22,7 @@
 #define MR_LOGGING_CONTEXT 0
 #endif
 
-#if __has_include("CocoaLumberjack.h")
+#if __has_include("CocoaLumberjack.h") || __has_include("CocoaLumberjack/CocoaLumberjack.h")
     #define MR_LOG_LEVEL_DEF (DDLogLevel)[MagicalRecord loggingLevel]
     #define CAST (DDLogFlag)
     #import <CocoaLumberjack/CocoaLumberjack.h>


### PR DESCRIPTION
I installed MagicalRecord 'v2.3.0' with Carthage. I already had CocoaLumberjack in the project as Framework. On Building I get a warning 'LOG_MAYBE macro redefined'. 
With this fix the warning goes away. 