### PR TITLE
Add __nullable attribute on groupingKeyPath / MR 3.0

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFetching.h
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFetching.h
@@ -18,25 +18,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 
-+ (NSFetchedResultsController *)MR_fetchController:(NSFetchRequest *)request delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate useFileCache:(BOOL)useFileCache groupedBy:(NSString *)groupKeyPath inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchController:(NSFetchRequest *)request delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate useFileCache:(BOOL)useFileCache groupedBy:(NSString *__nullable)groupKeyPath inContext:(NSManagedObjectContext *)context;
 
 + (NSFetchedResultsController *)MR_fetchAllSortedBy:(NSString *)sortTerm
                                           ascending:(BOOL)ascending
                                       withPredicate:(NSPredicate *__nullable)searchTerm
-                                            groupBy:(NSString *)groupingKeyPath
+                                            groupBy:(NSString *__nullable)groupingKeyPath
                                            delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
 + (NSFetchedResultsController *)MR_fetchAllSortedBy:(NSString *)sortTerm
                                           ascending:(BOOL)ascending
                                       withPredicate:(NSPredicate *__nullable)searchTerm
-                                            groupBy:(NSString *)groupingKeyPath
+                                            groupBy:(NSString *__nullable)groupingKeyPath
                                            delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate
                                           inContext:(NSManagedObjectContext *)context;
 
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending;
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate inContext:(NSManagedObjectContext *)context;
 
 #endif
 


### PR DESCRIPTION
As per docs sectionNameKeyPath can be nil to indicate that NSFetchedResultsController should generate a single section.