### PR TITLE
Fix crash when related attribute is a string / MR 3.0

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -330,7 +330,9 @@ NSString *const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"u
             relatedObject = [entityDescription MR_createInstanceInContext:[strongSelf managedObjectContext]];
         }
         //import or update
-        [relatedObject MR_importValuesForKeysWithObject:localObjectData];
+        if (![localObjectData isKindOfClass:[NSString class]]) {
+            [relatedObject MR_importValuesForKeysWithObject:localObjectData];
+        }
 
         [strongSelf MR_setObject:relatedObject forRelationship:relationshipInfo];
     };


### PR DESCRIPTION
I import a payload presented as array of dictionaries.

``` json
[
  {
    "relatedCategoryIdentifier": "Software",
    "string": "Something"
  }
]
```

Category relationship has userInfo set as following:

<img width="256" alt="screenshot 2015-12-25 16 53 26" src="https://cloud.githubusercontent.com/assets/704044/12003637/0c39ab18-ab28-11e5-836a-cf6bc3257d00.png">

While debugging I see it finds the related category using the configured `mappedKeyName` and `relatedAttributed`, I also have `distinctAttribute` set on models. 

Looking at the implementation of `MR_lookupObjectForRelationship` I see that it supports relationship lookup by having a string provided:

``` objc
// if its a primitive class, than handle singleRelatedObjectData as the key for relationship
if ([singleRelatedObjectData isKindOfClass:[NSString class]] ||
    [singleRelatedObjectData isKindOfClass:[NSNumber class]])
{
    relatedValue = singleRelatedObjectData;
}
```

So in my case `singleRelatedObjectData` is a string from `relatedCategoryIdentifier`. But then `MR_importValuesForKeysWithObject` is always called and that causes it to crash because it expects enumerable object and `NSString` is not. 

``` objc
//Look up any existing objects
NSManagedObject *relatedObject = [strongSelf MR_lookupObjectForRelationship:relationshipInfo fromData:localObjectData];

if (relatedObject == nil)
{
    //create if none exist
    NSEntityDescription *entityDescription = [relationshipInfo destinationEntity];
    relatedObject = [entityDescription MR_createInstanceInContext:[strongSelf managedObjectContext]];
}

//import or update
[relatedObject MR_importValuesForKeysWithObject:localObjectData];
```

The crash used to happen in `MR_setRelationship:relatedData:`:

``` objc
id relatedObjectData = [relationshipData valueForKeyPath:lookupKey];
```

Where `relationshipData` is an instance of `NSString`.

My fix is to simply avoid calling import for relationship established using string identifier. I don't check for `NSDictionary` because technically seed data can be an object that implements the same methods of `NSDictionary` or `NSFastEnumeration`. This is probably useful for generated seed data for test purposes or whatsoever. 

Merry christmas!
