### PR TITLE
Fixed concurrency issue in WorkingName property

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -102,12 +102,17 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
 
 - (void) MR_setWorkingName:(NSString *)workingName
 {
-    [[self userInfo] setObject:workingName forKey:MagicalRecordContextWorkingName];
+	[self performBlockAndWait:^{
+		[[self userInfo] setObject:workingName forKey:MagicalRecordContextWorkingName];
+	}];
 }
 
 - (NSString *) MR_workingName
 {
-    NSString *workingName = [[self userInfo] objectForKey:MagicalRecordContextWorkingName];
+	__block NSString *workingName;
+	[self performBlockAndWait:^{
+		workingName = [[self userInfo] objectForKey:MagicalRecordContextWorkingName];
+	}];
 
     if ([workingName length] == 0)
     {


### PR DESCRIPTION
When debugging an application with different contexts, using the `-com.apple.CoreData.ConcurrencyDebug 1` argument to spot CoreData concurrency problems, the debugger sometimes breaks into `MR_workingName` due to a CoreData concurrency error.

This fix ensures that the properties are accessed only on the queue that is used by the context.