### PR TITLE
Enable concurrency debugging by default, and address issues

### DIFF
--- a/Docs/GettingStarted.md
+++ b/Docs/GettingStarted.md
@@ -19,11 +19,3 @@ When using the default sqlite data store with the DEBUG flag set, if you change 
 And finally, before your app exits, you can use the clean up method:
 
 	[MagicalRecord cleanUp];
-	
-
-## Nested Contexts
-
-New in Core Data is support for related contexts. This is a super neat, and super fast feature. However, writing a wrapper that supports both is, frankly, more work that it's worth. However, the 1.8.3 version will be the last version that has dual support, and going forward, MagicalRecord will only work with the version of Core Data that supports nested managed object contexts.
-
-MagicalRecord provides a background saving queue so that saving all data is performed off the main thread, in the background. This means that it may be necessary to use *MR_saveNestedContexts* rather than the typical *MR_save* method in order to persist your changes all the way to your persistent store;
-

--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -1,21 +1,82 @@
-# Installation
+# Installing MagicalRecord
 
-1. In your Xcode Project, drag the *MagicalRecord* folder (under the main folder) into your project. 
-2. Add *MagicalRecord.h* file to your PCH file or your AppDelegate file.
-3. Optionally precede the *MagicalRecord.h* import with `#define MR_SHORTHAND` to your PCH file if you want to use MagicalRecord methods without the *MR_prefix* like `findAll` instead of `MR_findAll`
-4. Start writing code!
+**Adding MagicalRecord to your project is simple**: Just choose whichever method you're most comfortable with and follow the instructions below.
 
-# Requirements
+## Using Carthage
 
-MagicalRecord Platform Requirements:
+1. Add the following line to your `Cartfile`:
 
-* iOS5.x or newer, or Mac OS 10.7 and newer
-* ARC
+    ```yaml
+    github "MagicalPanda/MagicalRecord"
+    ```
 
-An iOS4 compatible version is available for use. Reference [tag 1.8.3](https://github.com/magicalpanda/MagicalRecord/tree/1.8.3).
+2. Run `carthage update` in your project directory.
+3. Drag the appropriate `MagicalRecord.framework` for your platform (located in `Carthage/Build/``) into your application’s Xcode project, and add it to the appropriate target(s).
 
-## ARC Support
 
-MagicalRecord fully supports ARC out of the box, there is no configuration necessary. 
-The last version to support manually managed memory is 1.8.3, and is available from the downloads page, or by switching to the 1.8.3 tag in the source.
+## Using CocoaPods
 
+One of the easiest ways to integrate MagicalRecord in your project is to use [CocoaPods](http://cocoapods.org/):
+
+1. Add the following line to your `Podfile`:
+
+    a. Plain
+
+    ````ruby
+    pod "MagicalRecord"
+    ````
+    b. With CocoaLumberjack as Logger
+
+    ````ruby
+    pod "MagicalRecord/CocoaLumberjack"
+    ````
+
+2. In your project directory, run `pod update`
+3. You should now be able to add `#import <MagicalRecord/MagicalRecord.h>` to any of your target's source files and begin using MagicalRecord!
+
+## Using an Xcode subproject
+
+Xcode sub-projects allow your project to use and build MagicalRecord as an implicit dependency.
+
+1. Add MagicalRecord to your project as a Git submodule:
+
+    ````
+    $ cd MyXcodeProjectFolder
+    $ git submodule add https://github.com/magicalpanda/MagicalRecord.git Vendor/MagicalRecord
+    $ git commit -m "Add MagicalRecord submodule"
+    ````
+
+2. Drag `Vendor/MagicalRecord/MagicalRecord.xcproj` into your existing Xcode project
+3. Navigate to your project's settings, then select the target you wish to add MagicalRecord to
+4. Navigate to **Build Phases** and expand the **Link Binary With Libraries** section
+5. Click the **+** and find the version of the MagicalRecord framework appropriate to your target's platform
+6. You should now be able to add `#import <MagicalRecord/MagicalRecord.h>` to any of your target's source files and begin using MagicalRecord!
+
+> **Note** Please be aware that if you've set Xcode's **Link Frameworks Automatically** to **No** then you may need to add the CoreData.framework to your project on iOS, as UIKit does not include Core Data by default. On OS X, Cocoa includes Core Data.
+
+# Shorthand Category Methods
+
+By default, all of the category methods that MagicalRecord provides are prefixed with `MR_`. This is inline with [Apple's recommendation not to create unadorned category methods to avoid naming clashes](https://developer.apple.com/library/mac/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW4).
+
+If you like, you can include the following headers to use shorter, non-prefixed category methods:
+
+```objective-c
+#import <MagicalRecord/MagicalRecord.h>
+#import <MagicalRecord/MagicalRecord+ShorthandMethods.h>
+#import <MagicalRecord/MagicalRecordShorthandMethodAliases.h>
+```
+
+If you're using Swift, you'll need to add these imports to your target's Objective-C bridging header.
+
+Once you've included the headers, you should call the `+[MagicalRecord enableShorthandMethods]` class method _before_ you setup/use MagicalRecord:
+
+```objective-c
+- (void)theMethodWhereYouSetupMagicalRecord
+{
+    [MagicalRecord enableShorthandMethods];
+
+    // Setup MagicalRecord as per usual
+}
+```
+
+**Please note that we do not offer support for this feature**. If it doesn't work, [please file an issue](https://github.com/magicalpanda/MagicalRecord/issues/new) and we'll fix it when we can.

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFetching.h
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalFetching.h
@@ -18,25 +18,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 
-+ (NSFetchedResultsController *)MR_fetchController:(NSFetchRequest *)request delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate useFileCache:(BOOL)useFileCache groupedBy:(NSString *)groupKeyPath inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchController:(NSFetchRequest *)request delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate useFileCache:(BOOL)useFileCache groupedBy:(NSString *__nullable)groupKeyPath inContext:(NSManagedObjectContext *)context;
 
 + (NSFetchedResultsController *)MR_fetchAllSortedBy:(NSString *)sortTerm
                                           ascending:(BOOL)ascending
                                       withPredicate:(NSPredicate *__nullable)searchTerm
-                                            groupBy:(NSString *)groupingKeyPath
+                                            groupBy:(NSString *__nullable)groupingKeyPath
                                            delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
 + (NSFetchedResultsController *)MR_fetchAllSortedBy:(NSString *)sortTerm
                                           ascending:(BOOL)ascending
                                       withPredicate:(NSPredicate *__nullable)searchTerm
-                                            groupBy:(NSString *)groupingKeyPath
+                                            groupBy:(NSString *__nullable)groupingKeyPath
                                            delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate
                                           inContext:(NSManagedObjectContext *)context;
 
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending;
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending inContext:(NSManagedObjectContext *)context;
 
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
-+ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate inContext:(NSManagedObjectContext *)context;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate;
++ (NSFetchedResultsController *)MR_fetchAllGroupedBy:(NSString *__nullable)group withPredicate:(NSPredicate *__nullable)searchTerm sortedBy:(NSString *)sortTerm ascending:(BOOL)ascending delegate:(id<NSFetchedResultsControllerDelegate> __nullable)delegate inContext:(NSManagedObjectContext *)context;
 
 #endif
 

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -87,6 +87,8 @@
         }
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([context concurrencyType] == NSConfinementConcurrencyType)
     {
         requestBlock();
@@ -95,6 +97,8 @@
     {
         [context performBlockAndWait:requestBlock];
     }
+#pragma clang diagnostic pop
+
     return results;
 }
 

--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -134,20 +134,18 @@
 
 + (instancetype)MR_createEntityWithDescription:(NSEntityDescription *)entityDescription inContext:(NSManagedObjectContext *)context
 {
-    NSEntityDescription *entity = entityDescription;
+    NSEntityDescription *entity = entityDescription ?: [self MR_entityDescriptionInContext:context];
 
-    if (!entity)
-    {
-        entity = [self MR_entityDescriptionInContext:context];
-    }
+    __block NSManagedObject *managedObject;
 
-    //    [NSEntityDescription insertNewObjectForEntityForName:[entity name] inManagedObjectContext:context];
-    NSManagedObject *managedObject = [[self alloc] initWithEntity:entity insertIntoManagedObjectContext:context];
+    [context performBlockAndWait:^{
+        managedObject = [[self alloc] initWithEntity:entity insertIntoManagedObjectContext:context];
 
-    if ([managedObject respondsToSelector:@selector(MR_awakeFromCreation)])
-    {
-        [managedObject MR_awakeFromCreation];
-    }
+        if ([managedObject respondsToSelector:@selector(MR_awakeFromCreation)])
+        {
+            [managedObject MR_awakeFromCreation];
+        }
+    }];
 
     return managedObject;
 }

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
@@ -101,7 +101,7 @@ NSString *const MagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalR
     void (^mergeBlock)(void) = ^{
 
         MRLogInfo(@"Merging changes From iCloud to %@ %@",
-                  [self MR_workingName],
+                  self.name,
                   ([NSThread isMainThread] ? @" *** on Main Thread ***" : @""));
 
         [self mergeChangesFromContextDidSaveNotification:notification];
@@ -124,7 +124,7 @@ NSString *const MagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalR
 
     void (^mergeBlock)(void) = ^{
         MRLogVerbose(@"Merging changes from %@ to %@ %@",
-                     [fromContext MR_workingName], [self MR_workingName],
+                     fromContext.name, self.name,
                      ([NSThread isMainThread] ? @" *** on Main Thread ***" : @""));
         [self mergeChangesFromContextDidSaveNotification:notification];
     };

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalObserving.m
@@ -17,6 +17,8 @@ NSString *const MagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalR
 
 - (void)MR_performBlock:(void (^)(void))block
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([self concurrencyType] == NSConfinementConcurrencyType)
     {
         block();
@@ -25,10 +27,13 @@ NSString *const MagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalR
     {
         [self performBlock:block];
     }
+#pragma clang diagnostic pop
 }
 
 - (void)MR_performBlockAndWait:(void (^)(void))block
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([self concurrencyType] == NSConfinementConcurrencyType)
     {
         block();
@@ -37,6 +42,7 @@ NSString *const MagicalRecordDidMergeChangesFromiCloudNotification = @"kMagicalR
     {
         [self performBlockAndWait:block];
     }
+#pragma clang diagnostic pop
 }
 
 #pragma mark - Context Observation Helpers

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
@@ -6,6 +6,8 @@
 //
 
 #import <CoreData/CoreData.h>
+#import "MagicalRecordDeprecated.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const MagicalRecordDidMergeChangesFromiCloudNotification;
@@ -17,17 +19,18 @@ extern NSString *const MagicalRecordDidMergeChangesFromiCloudNotification;
 + (NSManagedObjectContext *)MR_context NS_RETURNS_RETAINED;
 + (NSManagedObjectContext *)MR_mainQueueContext;
 + (NSManagedObjectContext *)MR_privateQueueContext;
-
-+ (NSManagedObjectContext *)MR_confinementContext;
-+ (NSManagedObjectContext *)MR_confinementContextWithParent:(NSManagedObjectContext *)parentContext;
-
 + (NSManagedObjectContext *)MR_privateQueueContextWithStoreCoordinator:(NSPersistentStoreCoordinator *)coordinator NS_RETURNS_RETAINED;
 
 - (NSString *)MR_description;
 - (NSString *)MR_parentChain;
 
-- (void)MR_setWorkingName:(NSString *)workingName;
-- (NSString *)MR_workingName;
+@end
+
+@interface NSManagedObjectContext (MagicalRecordDeprecated)
+
++ (NSManagedObjectContext *)MR_confinementContext MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("4.0", "a context with a type of `NSPrivateQueueConcurrencyType` or `NSMainQueueConcurrencyType`");
++ (NSManagedObjectContext *)MR_confinementContextWithParent:(NSManagedObjectContext *)parentContext MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("4.0", "a context with a type of `NSPrivateQueueConcurrencyType` or `NSMainQueueConcurrencyType`");
 
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
@@ -17,8 +17,8 @@ extern NSString *const MagicalRecordDidMergeChangesFromiCloudNotification;
 - (void)MR_obtainPermanentIDsForObjects:(NSArray *)objects;
 
 + (NSManagedObjectContext *)MR_context NS_RETURNS_RETAINED;
-+ (NSManagedObjectContext *)MR_mainQueueContext;
-+ (NSManagedObjectContext *)MR_privateQueueContext;
++ (NSManagedObjectContext *)MR_mainQueueContext NS_RETURNS_RETAINED;
++ (NSManagedObjectContext *)MR_privateQueueContext NS_RETURNS_RETAINED;
 + (NSManagedObjectContext *)MR_privateQueueContextWithStoreCoordinator:(NSPersistentStoreCoordinator *)coordinator NS_RETURNS_RETAINED;
 
 - (NSString *)MR_description;

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.h
@@ -16,7 +16,6 @@ extern NSString *const MagicalRecordDidMergeChangesFromiCloudNotification;
 
 - (void)MR_obtainPermanentIDsForObjects:(NSArray *)objects;
 
-+ (NSManagedObjectContext *)MR_context NS_RETURNS_RETAINED;
 + (NSManagedObjectContext *)MR_mainQueueContext NS_RETURNS_RETAINED;
 + (NSManagedObjectContext *)MR_privateQueueContext NS_RETURNS_RETAINED;
 + (NSManagedObjectContext *)MR_privateQueueContextWithStoreCoordinator:(NSPersistentStoreCoordinator *)coordinator NS_RETURNS_RETAINED;
@@ -28,6 +27,7 @@ extern NSString *const MagicalRecordDidMergeChangesFromiCloudNotification;
 
 @interface NSManagedObjectContext (MagicalRecordDeprecated)
 
++ (NSManagedObjectContext *)MR_context NS_RETURNS_RETAINED MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("3.1", "+MR_privateContext");
 + (NSManagedObjectContext *)MR_confinementContext MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("4.0", "a context with a type of `NSPrivateQueueConcurrencyType` or `NSMainQueueConcurrencyType`");
 + (NSManagedObjectContext *)MR_confinementContextWithParent:(NSManagedObjectContext *)parentContext MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("4.0", "a context with a type of `NSPrivateQueueConcurrencyType` or `NSMainQueueConcurrencyType`");
 

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -38,8 +38,7 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
 - (NSString *)MR_description
 {
     NSString *onMainThread = [NSThread isMainThread] ? @"*** MAIN THREAD ***" : @"*** BACKGROUND THREAD ***";
-
-    return [NSString stringWithFormat:@"%@ on %@", [self MR_workingName], onMainThread];
+    return [NSString stringWithFormat:@"%@ on %@", self.name, onMainThread];
 }
 
 - (NSString *)MR_debugDescription
@@ -53,7 +52,7 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
     NSManagedObjectContext *currentContext = self;
     do
     {
-        [familyTree appendFormat:@"- %@ (%p) %@\n", [currentContext MR_workingName], currentContext, (currentContext == self ? @"(*)" : @"")];
+        [familyTree appendFormat:@"- %@ (%p) %@\n", currentContext.name, currentContext, (currentContext == self ? @"(*)" : @"")];
     } while ((currentContext = [currentContext parentContext]));
 
     return [NSString stringWithString:familyTree];
@@ -74,31 +73,17 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
     return [self MR_privateQueueContext];
 }
 
-+ (NSManagedObjectContext *)MR_confinementContext
-{
-    NSManagedObjectContext *context = [[self alloc] initWithConcurrencyType:NSConfinementConcurrencyType];
-    [context MR_setWorkingName:@"Confinement"];
-    return context;
-}
-
-+ (NSManagedObjectContext *)MR_confinementContextWithParent:(NSManagedObjectContext *)parentContext
-{
-    NSManagedObjectContext *context = [self MR_confinementContext];
-    [context setParentContext:parentContext];
-    return context;
-}
-
 + (NSManagedObjectContext *)MR_mainQueueContext
 {
     NSManagedObjectContext *context = [[self alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-    [context MR_setWorkingName:@"Main Queue"];
+    context.name = @"Main Queue";
     return context;
 }
 
 + (NSManagedObjectContext *)MR_privateQueueContext
 {
     NSManagedObjectContext *context = [[self alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    [context MR_setWorkingName:@"Private Queue"];
+    context.name = @"Private Queue";
     return context;
 }
 
@@ -113,24 +98,9 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
             [context setPersistentStoreCoordinator:coordinator];
         }];
 
-        MRLogInfo(@"-> Created Context %@", [context MR_workingName]);
+        MRLogInfo(@"-> Created Context %@", context.name);
     }
     return context;
-}
-
-- (void)MR_setWorkingName:(NSString *)workingName
-{
-    [[self userInfo] setObject:workingName forKey:kMagicalRecordNSManagedObjectContextWorkingName];
-}
-
-- (NSString *)MR_workingName
-{
-    NSString *workingName = [[self userInfo] objectForKey:kMagicalRecordNSManagedObjectContextWorkingName];
-    if ([workingName length] == 0)
-    {
-        workingName = @"UNNAMED";
-    }
-    return workingName;
 }
 
 @end

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -103,4 +103,26 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
     return context;
 }
 
+#pragma mark - Deprecated Methods
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (NSManagedObjectContext *)MR_confinementContext
+{
+    NSManagedObjectContext *context = [[self alloc] initWithConcurrencyType:NSConfinementConcurrencyType];
+    context.name = @"Confinement";
+    return context;
+}
+
++ (NSManagedObjectContext *)MR_confinementContextWithParent:(NSManagedObjectContext *)parentContext
+{
+    NSManagedObjectContext *context = [self MR_confinementContext];
+    context.parentContext = parentContext;
+    return context;
+}
+
+#pragma clang diagnostic pop
+
 @end
+

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -21,11 +21,15 @@ NSString *MR_concurrencyStringFromType(NSManagedObjectContextConcurrencyType typ
     {
         return @"Main Queue";
     }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (type == NSConfinementConcurrencyType)
     {
         return @"Confinement";
     }
-
+#pragma clang diagnostic pop
+    
     return @"Unknown Concurrency";
 }
 

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -68,11 +68,6 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
     }
 }
 
-+ (NSManagedObjectContext *)MR_context
-{
-    return [self MR_privateQueueContext];
-}
-
 + (NSManagedObjectContext *)MR_mainQueueContext
 {
     NSManagedObjectContext *context = [[self alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
@@ -107,6 +102,11 @@ static NSString *const kMagicalRecordNSManagedObjectContextWorkingName = @"kNSMa
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (NSManagedObjectContext *)MR_context
+{
+    return [self MR_privateQueueContext];
+}
 
 + (NSManagedObjectContext *)MR_confinementContext
 {

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -105,7 +105,7 @@
 
     if (!hasChanges)
     {
-        MRLogInfo(@"NO CHANGES IN ** %@ ** CONTEXT - NOT SAVING", [self MR_workingName]);
+        MRLogInfo(@"NO CHANGES IN ** %@ ** CONTEXT - NOT SAVING", self.name);
 
         if (saveParentContexts && [self parentContext])
         {

--- a/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
+++ b/Library/Categories/CoreData/NSManagedObjectContext/NSManagedObjectContext+MagicalSaves.m
@@ -92,6 +92,8 @@
 
     __block BOOL hasChanges = NO;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([self concurrencyType] == NSConfinementConcurrencyType)
     {
         hasChanges = [self hasChanges];
@@ -102,6 +104,7 @@
             hasChanges = [self hasChanges];
         }];
     }
+#pragma clang diagnostic pop
 
     if (!hasChanges)
     {
@@ -182,6 +185,8 @@
         }
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([self concurrencyType] == NSConfinementConcurrencyType)
     {
         saveBlock();
@@ -194,6 +199,7 @@
     {
         [self performBlock:saveBlock];
     }
+#pragma clang diagnostic pop
 }
 
 @end

--- a/Library/MagicalMigrationManager.m
+++ b/Library/MagicalMigrationManager.m
@@ -107,9 +107,7 @@
 - (BOOL)MagicalMigrationManager_progressivelyMigrateStoreAtURL:(NSURL *)sourceStoreURL toStoreAtURL:(NSURL *)targetStoreURL ofType:(NSString *)type error:(NSError *__autoreleasing *)error
 {
     NSManagedObjectModel *targetModel = [self targetModel];
-    NSDictionary *sourceMetadata = [NSPersistentStoreCoordinator metadataForPersistentStoreOfType:type
-                                                                                              URL:sourceStoreURL
-                                                                                            error:error];
+    NSDictionary *sourceMetadata = [NSPersistentStoreCoordinator metadataForPersistentStoreOfType:type URL:sourceStoreURL options:nil error:error];
 
     if (nil == sourceMetadata)
     {

--- a/Library/MagicalRecordStack/ClassicSQLiteMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/ClassicSQLiteMagicalRecordStack.m
@@ -13,11 +13,11 @@
 
 @implementation ClassicSQLiteMagicalRecordStack
 
-- (NSManagedObjectContext *)newConfinementContext
+- (NSManagedObjectContext *)newPrivateQueueContext
 {
-    NSManagedObjectContext *context = [NSManagedObjectContext MR_confinementContext];
-    [context setPersistentStoreCoordinator:self.coordinator];
-    [context setMergePolicy:NSMergeByPropertyStoreTrumpMergePolicy];
+    NSManagedObjectContext *context = [super newPrivateQueueContext]; // TODO: This no longer represents a "classic" setup, as confinement concurrency is deprecated
+    context.persistentStoreCoordinator = self.coordinator;
+    context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
 
     //TODO: This observation needs to be torn down by the user at this time :(
     [self.context MR_observeContextDidSave:context];
@@ -33,12 +33,12 @@
     dispatch_async(MR_saveQueue(), ^{
         MRLogVerbose(@"%@ save starting", contextWorkingName);
 
-        NSManagedObjectContext *localContext = [self newConfinementContext];
+        NSManagedObjectContext *localContext = [self newPrivateQueueContext];
         NSManagedObjectContext *mainContext = [self context];
 
         [mainContext MR_observeContextDidSave:localContext];
         [mainContext setMergePolicy:NSMergeByPropertyStoreTrumpMergePolicy];
-        [localContext MR_setWorkingName:contextWorkingName];
+        localContext.name = contextWorkingName;
 
         block(localContext);
 

--- a/Library/MagicalRecordStack/ClassicWithBackgroundCoordinatorSQLiteMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/ClassicWithBackgroundCoordinatorSQLiteMagicalRecordStack.m
@@ -37,12 +37,12 @@
     [super reset];
 }
 
-- (NSManagedObjectContext *)newConfinementContext
+- (NSManagedObjectContext *)newPrivateQueueContext
 {
     //TODO: need to setup backgroundContext -> context merges via NSNC, and unsubscribe automatically
-    NSManagedObjectContext *backgroundContext = [NSManagedObjectContext MR_confinementContext];
-    [backgroundContext setPersistentStoreCoordinator:self.backgroundCoordinator];
-    return backgroundContext;
+    NSManagedObjectContext *context = [super newPrivateQueueContext];
+    context.persistentStoreCoordinator = self.backgroundCoordinator;
+    return context;
 }
 
 - (NSPersistentStoreCoordinator *)backgroundCoordinator

--- a/Library/MagicalRecordStack/InMemoryMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/InMemoryMagicalRecordStack.m
@@ -12,19 +12,17 @@
 
 @implementation InMemoryMagicalRecordStack
 
-- (NSManagedObjectContext *)newConfinementContext
+- (NSManagedObjectContext *)newPrivateQueueContext
 {
-    NSManagedObjectContext *context = [super createConfinementContext];
-    [context setParentContext:[self context]];
+    NSManagedObjectContext *context = [super newPrivateQueueContext];
+    context.parentContext = self.context;
     return context;
 }
 
 - (NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(NSDictionary *)options
 {
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self model]];
-
     [coordinator MR_addInMemoryStoreWithOptions:options];
-
     return coordinator;
 }
 

--- a/Library/MagicalRecordStack/MagicalRecordStack+Private.h
+++ b/Library/MagicalRecordStack/MagicalRecordStack+Private.h
@@ -8,7 +8,6 @@
 - (nonnull NSPersistentStoreCoordinator *)createCoordinator;
 - (nonnull NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(nullable NSDictionary *)options;
 
-- (nonnull NSManagedObjectContext *)createConfinementContext;
 - (void)loadStack;
 
 @end

--- a/Library/MagicalRecordStack/MagicalRecordStack.h
+++ b/Library/MagicalRecordStack/MagicalRecordStack.h
@@ -25,6 +25,7 @@
 
 - (void)reset;
 
+- (nonnull NSManagedObjectContext *)newMainQueueContext;
 - (nonnull NSManagedObjectContext *)newPrivateQueueContext;
 
 - (void)setModelFromClass:(nonnull Class)modelClass;

--- a/Library/MagicalRecordStack/MagicalRecordStack.h
+++ b/Library/MagicalRecordStack/MagicalRecordStack.h
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+#import "MagicalRecordDeprecated.h"
 
 @interface MagicalRecordStack : NSObject
 
@@ -24,9 +25,15 @@
 
 - (void)reset;
 
-- (nonnull NSManagedObjectContext *)newConfinementContext;
+- (nonnull NSManagedObjectContext *)newPrivateQueueContext;
 
 - (void)setModelFromClass:(nonnull Class)modelClass;
 - (void)setModelNamed:(nonnull NSString *)modelName;
+
+@end
+
+@interface MagicalRecordStack (MagicalRecordDeprecated)
+
+- (nonnull NSManagedObjectContext *)newConfinementContext MR_DEPRECATED_WILL_BE_REMOVED_IN_PLEASE_USE("4.0", "a context with a type of `NSPrivateQueueConcurrencyType` or `NSMainQueueConcurrencyType`");
 
 @end

--- a/Library/MagicalRecordStack/MagicalRecordStack.m
+++ b/Library/MagicalRecordStack/MagicalRecordStack.m
@@ -92,6 +92,14 @@ static MagicalRecordStack *defaultStack;
     _store = nil;
 }
 
+- (NSManagedObjectContext *)newMainQueueContext
+{
+    NSManagedObjectContext *context = [NSManagedObjectContext MR_mainQueueContext];
+    context.name = [context.name stringByAppendingFormat:@" (%@)", self.stackName];
+    context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+    return context;
+}
+
 - (NSManagedObjectContext *)newPrivateQueueContext
 {
     NSManagedObjectContext *context = [NSManagedObjectContext MR_privateQueueContext];

--- a/Library/MagicalRecordStack/SQLiteMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/SQLiteMagicalRecordStack.m
@@ -108,10 +108,10 @@
     return [self createCoordinatorWithOptions:[self defaultStoreOptions]];
 }
 
-- (NSManagedObjectContext *)newConfinementContext
+- (NSManagedObjectContext *)newPrivateQueueContext
 {
-    NSManagedObjectContext *context = [super newConfinementContext];
-    [context setParentContext:[self context]];
+    NSManagedObjectContext *context = [super newPrivateQueueContext];
+    context.parentContext = self.context;
     return context;
 }
 

--- a/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
@@ -45,11 +45,4 @@
     return _context;
 }
 
-- (NSManagedObjectContext *)newConfinementContext
-{
-    NSManagedObjectContext *context = [super createConfinementContext];
-    [context setParentContext:[self savingContext]];
-    return context;
-}
-
 @end

--- a/MagicalRecord.podspec
+++ b/MagicalRecord.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.requires_arc = true
   s.default_subspec = 'Core'
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
 
   s.subspec "Core" do |sp|
     sp.framework    = 'CoreData'

--- a/MagicalRecord.xcodeproj/project.pbxproj
+++ b/MagicalRecord.xcodeproj/project.pbxproj
@@ -932,27 +932,27 @@
 		C7790F9E17E63C3100D20ACF /* Stacks */ = {
 			isa = PBXGroup;
 			children = (
-				C7790FA517E63C3100D20ACF /* MagicalRecordStack.h */,
-				C771EB3817E6AC2C00D2E984 /* MagicalRecordStack+Private.h */,
-				C7790FA617E63C3100D20ACF /* MagicalRecordStack.m */,
-				C771EB3917E6AD3100D2E984 /* MagicalRecordStack+Actions.h */,
-				C771EB3A17E6AD3100D2E984 /* MagicalRecordStack+Actions.m */,
+				C7790F9F17E63C3100D20ACF /* AutoMigratingMagicalRecordStack.h */,
+				C7790FA017E63C3100D20ACF /* AutoMigratingMagicalRecordStack.m */,
+				C79D63E0180880A9006C29E3 /* AutoMigratingWithSourceAndTargetModelMagicalRecordStack.h */,
+				C79D63E1180880A9006C29E3 /* AutoMigratingWithSourceAndTargetModelMagicalRecordStack.m */,
 				C7B687FA181594140002C92E /* ClassicSQLiteMagicalRecordStack.h */,
 				C7B687FB181594140002C92E /* ClassicSQLiteMagicalRecordStack.m */,
 				C73A7CDB180CF7A700E305D8 /* ClassicWithBackgroundCoordinatorSQLiteMagicalRecordStack.h */,
 				C73A7CDC180CF7A700E305D8 /* ClassicWithBackgroundCoordinatorSQLiteMagicalRecordStack.m */,
+				C7790FA317E63C3100D20ACF /* InMemoryMagicalRecordStack.h */,
+				C7790FA417E63C3100D20ACF /* InMemoryMagicalRecordStack.m */,
+				C7790FA517E63C3100D20ACF /* MagicalRecordStack.h */,
+				C7790FA617E63C3100D20ACF /* MagicalRecordStack.m */,
+				C771EB3917E6AD3100D2E984 /* MagicalRecordStack+Actions.h */,
+				C771EB3A17E6AD3100D2E984 /* MagicalRecordStack+Actions.m */,
+				C771EB3817E6AC2C00D2E984 /* MagicalRecordStack+Private.h */,
+				C7790FA717E63C3100D20ACF /* ManuallyMigratingMagicalRecordStack.h */,
+				C7790FA817E63C3100D20ACF /* ManuallyMigratingMagicalRecordStack.m */,
 				C7790FA917E63C3100D20ACF /* SQLiteMagicalRecordStack.h */,
 				C7790FAA17E63C3100D20ACF /* SQLiteMagicalRecordStack.m */,
 				C771EB2B17E6951900D2E984 /* SQLiteWithSavingContextMagicalRecordStack.h */,
 				C771EB2C17E6951900D2E984 /* SQLiteWithSavingContextMagicalRecordStack.m */,
-				C7790F9F17E63C3100D20ACF /* AutoMigratingMagicalRecordStack.h */,
-				C7790FA017E63C3100D20ACF /* AutoMigratingMagicalRecordStack.m */,
-				C7790FA717E63C3100D20ACF /* ManuallyMigratingMagicalRecordStack.h */,
-				C7790FA817E63C3100D20ACF /* ManuallyMigratingMagicalRecordStack.m */,
-				C79D63E0180880A9006C29E3 /* AutoMigratingWithSourceAndTargetModelMagicalRecordStack.h */,
-				C79D63E1180880A9006C29E3 /* AutoMigratingWithSourceAndTargetModelMagicalRecordStack.m */,
-				C7790FA317E63C3100D20ACF /* InMemoryMagicalRecordStack.h */,
-				C7790FA417E63C3100D20ACF /* InMemoryMagicalRecordStack.m */,
 			);
 			name = Stacks;
 			path = MagicalRecordStack;
@@ -1581,7 +1581,6 @@
 				);
 				INFOPLIST_FILE = "Tests/Support/MagicalRecordTests-iOS-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-all_load",
@@ -1607,7 +1606,6 @@
 				);
 				INFOPLIST_FILE = "Tests/Support/MagicalRecordTests-iOS-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-all_load",
@@ -1631,7 +1629,6 @@
 					"\"$(SRCROOT)/Tests/Vendor/Expecta/src\"/**",
 				);
 				INFOPLIST_FILE = "Tests/Support/MagicalRecordTests-OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-all_load",
@@ -1655,7 +1652,6 @@
 					"\"$(SRCROOT)/Tests/Vendor/Expecta/src\"/**",
 				);
 				INFOPLIST_FILE = "Tests/Support/MagicalRecordTests-OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-all_load",
@@ -1730,7 +1726,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
@@ -1810,7 +1806,7 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS = YES;
 				OTHER_CFLAGS = (
 					"-DNDEBUG",

--- a/Tests/Abstract/MagicalRecordTestBase.h
+++ b/Tests/Abstract/MagicalRecordTestBase.h
@@ -11,13 +11,4 @@
 
 @property (readwrite, nonatomic, strong) MagicalRecordStack *stack;
 
-/**
- *  Setup and return a new Magical Record stack. Returns an in-memory stack by
- *  default. Subclasses can override this and return a suitable stack for
- *  the tests they are performing.
- *
- *  @return New instance of one of the MagicalRecordStack subclasses.
- */
-+ (MagicalRecordStack *)newMagicalRecordStack;
-
 @end

--- a/Tests/Abstract/MagicalRecordTestBase.m
+++ b/Tests/Abstract/MagicalRecordTestBase.m
@@ -12,11 +12,12 @@
     [super setUp];
 
     // Don't pollute the tests with logging
-    [MagicalRecord setLoggingLevel:MagicalRecordLoggingLevelOff];
+    [MagicalRecord setLoggingLevel:MagicalRecordLoggingLevelVerbose];
 
     // Setup a usable stack
-    self.stack = [[self class] newMagicalRecordStack];
-    [self.stack setModelFromClass:[self class]];
+    MagicalRecordStack *testStack = [InMemoryMagicalRecordStack stack];
+    [testStack setModelFromClass:[self class]];
+    self.stack = testStack;
 }
 
 - (void)tearDown
@@ -24,11 +25,6 @@
     [super tearDown];
 
     [self.stack reset];
-}
-
-+ (MagicalRecordStack *)newMagicalRecordStack
-{
-    return [InMemoryMagicalRecordStack stack];
 }
 
 @end

--- a/Tests/Core/NSManagedObjectContext+MagicalObserving.m
+++ b/Tests/Core/NSManagedObjectContext+MagicalObserving.m
@@ -19,15 +19,26 @@
 
     NSManagedObject *testEntity = [SingleEntityWithNoRelationships MR_createEntityInContext:otherContext];
     XCTAssertNotNil(testEntity);
-    XCTAssertTrue(otherContext.hasChanges);
-    XCTAssertFalse(stackContext.hasChanges);
+
+    [otherContext performBlockAndWait:^{
+        XCTAssertTrue(otherContext.hasChanges);
+    }];
+
+    [stackContext performBlockAndWait:^{
+        XCTAssertFalse(stackContext.hasChanges);
+    }];
 
     [stackContext MR_observeContextDidSaveAndSaveChangesToSelf:otherContext];
 
     [otherContext MR_saveOnlySelfAndWait];
 
-    XCTAssertFalse(otherContext.hasChanges);
-    XCTAssertFalse(stackContext.hasChanges);
+    [otherContext performBlockAndWait:^{
+        XCTAssertFalse(otherContext.hasChanges);
+    }];
+
+    [stackContext performBlockAndWait:^{
+        XCTAssertFalse(stackContext.hasChanges);
+    }];
 }
 
 @end

--- a/Tests/Core/NSManagedObjectContext+MagicalRecordTests.m
+++ b/Tests/Core/NSManagedObjectContext+MagicalRecordTests.m
@@ -14,7 +14,8 @@
 - (void)testCanNotifyDefaultContextOnSave
 {
     NSManagedObjectContext *stackContext = self.stack.context;
-    NSManagedObjectContext *testContext = [NSManagedObjectContext MR_confinementContextWithParent:stackContext];
+    NSManagedObjectContext *testContext = [NSManagedObjectContext MR_privateQueueContext];
+    testContext.parentContext = stackContext;
     XCTAssertEqualObjects(testContext.parentContext, stackContext);
 }
 

--- a/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
+++ b/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
@@ -16,32 +16,57 @@
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_privateQueueContext];
     childContext.parentContext = parentContext;
 
-    SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
-    XCTAssertTrue(insertedObject.hasChanges);
+    XCTestExpectation *childContextSavedExpectation = [self expectationWithDescription:@"Child Context Did Save"];
 
-    NSError *obtainIDsError;
-    BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
-    XCTAssertTrue(obtainIDsResult);
-    XCTAssertNil(obtainIDsError);
+    __block NSManagedObjectID *insertedObjectID;
 
-    NSManagedObjectID *insertedObjectID = [insertedObject objectID];
-    XCTAssertNotNil(insertedObjectID);
-    XCTAssertFalse(insertedObjectID.isTemporaryID);
+    [childContext performBlockAndWait:^{
+        SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
+        XCTAssertTrue(insertedObject.hasChanges);
 
-    NSError *saveError;
-    BOOL saveResult = [childContext MR_saveOnlySelfAndWaitWithError:&saveError];
-    XCTAssertTrue(saveResult);
-    XCTAssertNil(saveError);
+        NSError *obtainIDsError;
+        BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
-    NSManagedObject *parentContextFetchedObject = [parentContext objectRegisteredForID:insertedObjectID];
+        insertedObjectID = [insertedObject objectID];
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
 
-    XCTAssertNotNil(parentContextFetchedObject);
-    XCTAssertTrue(parentContextFetchedObject.hasChanges, @"Saving a child context moves the saved changes up to the parent, but does not save them, leaving the parent context with changes");
+        NSError *saveError;
+        BOOL saveResult = [childContext MR_saveOnlySelfAndWaitWithError:&saveError];
+        XCTAssertTrue(saveResult);
+        XCTAssertNil(saveError);
+        [childContextSavedExpectation fulfill];
+    }];
 
-    NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
+    XCTestExpectation *parentContextSavedExpectation = [self expectationWithDescription:@"Parent Context Did Save"];
+    childContextSavedExpectation = [self expectationWithDescription:@"Child Context Did Save"];
 
-    XCTAssertNotNil(childContextFetchedObject);
-    XCTAssertFalse(childContextFetchedObject.hasChanges, @"The child context should not have changes after the save");
+    [parentContext performBlockAndWait:^{
+        NSManagedObject *parentContextFetchedObject = [parentContext objectRegisteredForID:insertedObjectID];
+
+        XCTAssertNotNil(parentContextFetchedObject);
+        XCTAssertTrue(parentContextFetchedObject.hasChanges, @"Saving a child context moves the saved changes up to the parent, but does not save them, leaving the parent context with changes");
+
+        [childContext performBlockAndWait:^{
+            NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
+
+            XCTAssertNotNil(childContextFetchedObject);
+            XCTAssertFalse(childContextFetchedObject.hasChanges, @"The child context should not have changes after the save");
+
+            [childContextSavedExpectation fulfill];
+        }];
+
+        [parentContextSavedExpectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *_Nullable error) {
+        if (error)
+        {
+            NSLog(@"Timeout Error: %@", error);
+        }
+    }];
 }
 
 - (void)testSaveToSelfOnlyWhenSaveIsAsynchronous
@@ -50,42 +75,50 @@
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_privateQueueContext];
     childContext.parentContext = parentContext;
 
-    SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
-    XCTAssertTrue(insertedObject.hasChanges);
+    XCTestExpectation *childContextExpectation = [self expectationWithDescription:@"Child Context Completed Work"];
+    XCTestExpectation *childContextSaveExpectation = [self expectationWithDescription:@"Child Context Saved"];
+    XCTestExpectation *parentContextExpectation = [self expectationWithDescription:@"Parent Context Completed Work"];
 
-    NSError *obtainIDsError;
-    BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
-    XCTAssertTrue(obtainIDsResult);
-    XCTAssertNil(obtainIDsError);
+    [childContext performBlock:^{
+        SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
+        XCTAssertTrue(insertedObject.hasChanges);
 
-    NSManagedObjectID *insertedObjectID = [insertedObject objectID];
-    XCTAssertNotNil(insertedObjectID);
-    XCTAssertFalse(insertedObjectID.isTemporaryID);
+        NSError *obtainIDsError;
+        BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
-    __block NSManagedObject *parentContextFetchedObject;
-    __block NSManagedObject *childContextFetchedObject;
+        NSManagedObjectID *insertedObjectID = [insertedObject objectID];
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for asynchronous context to save"];
+        [childContext MR_saveOnlySelfWithCompletion:^(BOOL success, NSError *error) {
+            XCTAssertTrue(success);
+            XCTAssertNil(error);
 
-    [childContext MR_saveOnlySelfWithCompletion:^(BOOL success, NSError *error) {
-        XCTAssertTrue(success);
-        XCTAssertNil(error);
+            [childContext performBlock:^{
+                XCTAssertFalse(childContext.hasChanges, @"Child context should not have changes after the save has completed");
+                [childContextSaveExpectation fulfill];
+            }];
 
-        parentContextFetchedObject = [parentContext objectRegisteredForID:insertedObjectID];
-        childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
+            [parentContext performBlock:^{
+                NSManagedObject *parentContextFetchedObject = [parentContext objectRegisteredForID:insertedObjectID];
+                XCTAssertNotNil(parentContextFetchedObject);
+                XCTAssertTrue(parentContextFetchedObject.hasChanges, @"Saves from child contexts should leave changes in the parent");
+                [parentContextExpectation fulfill];
+            }];
 
-        [expectation fulfill];
+        }];
+
+        [childContextExpectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error) {
-        if (error) {
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *_Nullable error) {
+        if (error)
+        {
             NSLog(@"Timeout Error: %@", error);
         }
     }];
-
-    XCTAssertNotNil(parentContextFetchedObject);
-    XCTAssertTrue(parentContextFetchedObject.hasChanges, @"Saves from child contexts should leave changes in the parent");
-    XCTAssertFalse(childContext.hasChanges, @"Child context should not have changes after the save has completed");
 }
 
 - (void)testSaveToSelfOnlyWhenSaveIsAsynchronousCallsCorrectThreadOnCompletion
@@ -124,32 +157,45 @@
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_privateQueueContext];
     childContext.parentContext = parentContext;
 
-    SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
-    XCTAssertTrue(insertedObject.hasChanges);
+    __block NSManagedObjectID *insertedObjectID;
 
-    NSError *obtainIDsError;
-    BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
-    XCTAssertTrue(obtainIDsResult);
-    XCTAssertNil(obtainIDsError);
+    [childContext performBlockAndWait:^{
+        SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
 
-    NSManagedObjectID *insertedObjectID = [insertedObject objectID];
-    XCTAssertNotNil(insertedObjectID);
-    XCTAssertFalse(insertedObjectID.isTemporaryID);
+        XCTAssertTrue(insertedObject.hasChanges);
+
+        NSError *obtainIDsError;
+        BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
+
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
+
+        insertedObjectID = [insertedObject objectID];
+
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
+    }];
 
     NSError *saveError;
     BOOL saveResult = [childContext MR_saveToPersistentStoreAndWaitWithError:&saveError];
     XCTAssertTrue(saveResult);
     XCTAssertNil(saveError);
 
-    NSError *fetchExistingObjectFromParentContextError;
-    NSManagedObject *parentContextFetchedObject = [parentContext existingObjectWithID:insertedObjectID error:&fetchExistingObjectFromParentContextError];
-    XCTAssertNil(fetchExistingObjectFromParentContextError);
-    XCTAssertNotNil(parentContextFetchedObject);
-    XCTAssertFalse(parentContextFetchedObject.hasChanges, @"Saving to the persistent store should save to all parent contexts, leaving no changes");
+    [parentContext performBlockAndWait:^{
+        NSError *fetchExistingObjectFromParentContextError;
+        NSManagedObject *parentContextFetchedObject = [parentContext existingObjectWithID:insertedObjectID error:&fetchExistingObjectFromParentContextError];
 
-    NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
-    XCTAssertNotNil(childContextFetchedObject);
-    XCTAssertFalse(childContextFetchedObject.hasChanges, @"The child context should not have changes after the save");
+        XCTAssertNil(fetchExistingObjectFromParentContextError);
+        XCTAssertNotNil(parentContextFetchedObject);
+        XCTAssertFalse(parentContextFetchedObject.hasChanges, @"Saving to the persistent store should save to all parent contexts, leaving no changes");
+    }];
+
+    [childContext performBlockAndWait:^{
+        NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
+
+        XCTAssertNotNil(childContextFetchedObject);
+        XCTAssertFalse(childContextFetchedObject.hasChanges, @"The child context should not have changes after the save");
+    }];
 }
 
 - (void)testSaveToPersistentStoreWhenSaveIsAsynchronous
@@ -158,44 +204,51 @@
     NSManagedObjectContext *childContext = [NSManagedObjectContext MR_privateQueueContext];
     childContext.parentContext = parentContext;
 
-    SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
-    XCTAssertTrue(insertedObject.hasChanges);
+    XCTestExpectation *childContextExpectation = [self expectationWithDescription:@"Child Context Completed Work"];
+    XCTestExpectation *childContextSavedExpectation = [self expectationWithDescription:@"Child Context Saved"];
 
-    NSError *obtainIDsError;
-    BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
-    XCTAssertTrue(obtainIDsResult);
-    XCTAssertNil(obtainIDsError);
+    [childContext performBlock:^{
+        SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
+        XCTAssertTrue(insertedObject.hasChanges);
 
-    NSManagedObjectID *insertedObjectID = [insertedObject objectID];
-    XCTAssertNotNil(insertedObjectID);
-    XCTAssertFalse(insertedObjectID.isTemporaryID);
+        NSError *obtainIDsError;
+        BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
-    __block NSManagedObject *parentContextFetchedObject;
-    __block NSManagedObject *childContextFetchedObject;
-    __block NSError *fetchExistingObjectFromParentContextError;
+        NSManagedObjectID *insertedObjectID = [insertedObject objectID];
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for asynchronous context to save"];
+        [childContext MR_saveToPersistentStoreWithCompletion:^(BOOL success, NSError *error) {
+            XCTAssertTrue(success);
+            XCTAssertNil(error);
 
-    [childContext MR_saveToPersistentStoreWithCompletion:^(BOOL success, NSError *error) {
-        XCTAssertTrue(success);
-        XCTAssertNil(error);
+            [parentContext performBlockAndWait:^{
+                NSError *fetchExistingObjectFromParentContextError;
+                NSManagedObject *parentContextFetchedObject = [parentContext existingObjectWithID:insertedObjectID error:&fetchExistingObjectFromParentContextError];
 
-        parentContextFetchedObject = [parentContext existingObjectWithID:insertedObjectID error:&fetchExistingObjectFromParentContextError];
-        childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
+                XCTAssertNil(fetchExistingObjectFromParentContextError);
+                XCTAssertNotNil(parentContextFetchedObject);
+                XCTAssertFalse(parentContextFetchedObject.hasChanges, @"Saving to the persistent store should save to all parent contexts, leaving no changes");
+            }];
 
-        [expectation fulfill];
+            [childContext performBlockAndWait:^{
+                XCTAssertFalse(childContext.hasChanges, @"The child context should not have changes after the save");
+            }];
+
+            [childContextSavedExpectation fulfill];
+        }];
+
+        [childContextExpectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error) {
-        if (error) {
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *_Nullable error) {
+        if (error)
+        {
             NSLog(@"Timeout Error: %@", error);
         }
     }];
-
-    XCTAssertNil(fetchExistingObjectFromParentContextError);
-    XCTAssertNotNil(parentContextFetchedObject);
-    XCTAssertFalse(parentContextFetchedObject.hasChanges, @"Saving to the persistent store should save to all parent contexts, leaving no changes");
-    XCTAssertFalse(childContext.hasChanges, @"The child context should not have changes after the save");
 }
 
 - (void)testThatSavedObjectsHavePermanentIDs


### PR DESCRIPTION
:fire: Please don't merge this yet - it's unfinished :fire:

- [x] Build and run tests with concurrency debug active
- [ ] Deprecate confinement contexts in 3.0, with a view to their complete removal in MR 4.0
- [ ] Make Stacks use either private or main queue contexts, or if there is no point without the confinement context, deprecate the stack.
- [ ] Update documentation
- [ ] Add tests for all added methods