### PR TITLE
Couple of updates for concurrency debug branch

### DIFF
--- a/Library/MagicalRecord/MagicalRecordShorthand.h
+++ b/Library/MagicalRecord/MagicalRecordShorthand.h
@@ -140,8 +140,6 @@
 + (NSManagedObjectContext *)confinementContextWithParent:(NSManagedObjectContext *)parentContext;
 + (NSManagedObjectContext *)privateQueueContextWithStoreCoordinator:(NSPersistentStoreCoordinator *)coordinator NS_RETURNS_RETAINED;
 - (NSString *)parentChain;
-- (void)setWorkingName:(NSString *)workingName;
-- (NSString *)workingName;
 
 @end
 

--- a/Library/MagicalRecord/MagicalRecordShorthand.m
+++ b/Library/MagicalRecord/MagicalRecordShorthand.m
@@ -421,16 +421,6 @@
     return [self MR_parentChain];
 }
 
-- (void)setWorkingName:(NSString *)workingName
-{
-    return [self MR_setWorkingName:workingName];
-}
-
-- (NSString *)workingName
-{
-    return [self MR_workingName];
-}
-
 @end
 
 @implementation NSManagedObjectContext (MagicalSavesShortHand)

--- a/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
@@ -46,8 +46,11 @@
 }
 
 - (NSManagedObjectContext *)newPrivateQueueContext {
-    NSManagedObjectContext *context = [super newPrivateQueueContext];
+    NSManagedObjectContext *context = [NSManagedObjectContext MR_privateQueueContext];
     context.parentContext = self.savingContext;
+    context.name = [context.name stringByAppendingFormat:@" (%@)", self.stackName];
+    context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+    
     return context;
 }
 

--- a/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
+++ b/Library/MagicalRecordStack/SQLiteWithSavingContextMagicalRecordStack.m
@@ -45,4 +45,10 @@
     return _context;
 }
 
+- (NSManagedObjectContext *)newPrivateQueueContext {
+    NSManagedObjectContext *context = [super newPrivateQueueContext];
+    context.parentContext = self.savingContext;
+    return context;
+}
+
 @end


### PR DESCRIPTION
- Added -newPrivateContext for SQLite stack with saving context
- Dropped old -workingName methods

Besides I think persistent store initialization should be entirely moved out from accessors for `-context`, `-coordinator` and such. I have some funky side effects when a call to -coordinator rolls out infinite loop initialization and crash because ivars are not set and this happens in response to notification sent at the point when new store is added. 

`-loadStack` is really a good place to do all that work at once. This is particularly important for iCloud stack which posts important notifications right away.

That's why I had to implement my own `createCoordinatorWithOptions` in iCloud stack:

``` objc
- (NSPersistentStoreCoordinator *)createCoordinatorWithOptions:(NSDictionary *)options
{
    MRLogVerbose(@"Loading Store at URL: %@", self.storeURL);
    NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self model]];

    // register for storesWillChange, storesDidChange, etc..
    // otherwise we'll miss them...
    [self registerForiCloudNotifications:coordinator];

    NSMutableDictionary *storeOptions = [options mutableCopy];
    [storeOptions addEntriesFromDictionary:self.storeOptions];

    NSPersistentStore *store = [coordinator MR_addSqliteStoreAtURL:self.storeURL withOptions:storeOptions];

   // ...
}
```
