### PR TITLE
Added protection for nil entity in context

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -218,12 +218,12 @@ static NSUInteger kMagicalRecordDefaultBatchSize = 20;
 - (BOOL) MR_deleteEntityInContext:(NSManagedObjectContext *)context
 {
     NSError *error = nil;
-    NSManagedObject *inContext = [context existingObjectWithID:[self objectID] error:&error];
-
+    NSManagedObject *entityInContext = [context existingObjectWithID:[self objectID] error:&error];
     [MagicalRecord handleErrors:error];
+    if (entityInContext) {
+        [context deleteObject:entityInContext];
+    }
 
-    [context deleteObject:inContext];
-    
     return YES;
 }
 


### PR DESCRIPTION
Seeing this in-frequent crash happen in my app

`-deleteObject: requires a non-nil argument`

<img width="913" alt="issue__1010_-_amrc___instabug" src="https://cloud.githubusercontent.com/assets/501631/12471692/0d3b6104-bfce-11e5-9e7c-aeb239ea735e.png">
