### PR TITLE
Fixed issue when parmamendIDs was already obtained but NSManagedObject wasn't saved

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.m
@@ -287,8 +287,8 @@ static NSUInteger kMagicalRecordDefaultBatchSize = 20;
     
     if ([[self objectID] isTemporaryID])
     {
-        BOOL success = [[self managedObjectContext] obtainPermanentIDsForObjects:@[self] error:&error];
-        if (!success)
+        [[self managedObjectContext] obtainPermanentIDsForObjects:@[self] error:&error];
+        if (error)
         {
             [MagicalRecord handleErrors:error];
             return nil;


### PR DESCRIPTION

There can be situation than permamentID was already obtained but context wasn't saved to persistent store so NSManagedObject will have still temporaryID.

1. A in localContext --save--> A in mainContext (not saving to persistent store) --> obtainPermamentID
2. localContext2 <--fetch A -- mainContext  (not saving to persistent store)
3. localContext2 --save--> mainContext
4. MR_inContext:mainContext  called on A from localContext 

MR_inContext will return nil instead of NSManagedObject if he was already obtained .
