### PR TITLE
Expose +MR_coordinatorWithSqliteStoreNamed:withOptions: as a public API

### DIFF
--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.h
@@ -26,7 +26,9 @@ OBJC_EXPORT NSString * __MR_nonnull const kMagicalRecordPSCMismatchCouldNotRecre
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_newPersistentStoreCoordinator NS_RETURNS_RETAINED;
 
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithSqliteStoreNamed:(MR_nonnull NSString *)storeFileName;
++ (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithSqliteStoreNamed:(MR_nonnull NSString *)storeFileName withOptions:(MR_nullable __autoreleasing NSDictionary *)options;
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithAutoMigratingSqliteStoreNamed:(MR_nonnull NSString *)storeFileName;
++ (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithAutoMigratingSqliteStoreNamed:(MR_nonnull NSString *)storeFileName withOptions:(MR_nullable __autoreleasing NSDictionary *)options;
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithSqliteStoreAtURL:(MR_nonnull NSURL *)storeURL;
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithAutoMigratingSqliteStoreAtURL:(MR_nonnull NSURL *)storeURL;
 + (MR_nonnull NSPersistentStoreCoordinator *) MR_coordinatorWithPersistentStore:(MR_nonnull NSPersistentStore *)persistentStore;

--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -249,6 +249,13 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
     return [self MR_addSqliteStoreNamed:storeFileName withOptions:options];
 }
 
+- (NSPersistentStore *) MR_addAutoMigratingSqliteStoreNamed:(NSString *) storeFileName withOptions:(NSDictionary *) options
+{
+    NSMutableDictionary *sqliteOptions = [NSMutableDictionary dictionaryWithDictionary:[[self class] MR_autoMigrationOptions]];
+    [sqliteOptions addEntriesFromDictionary:options];
+    return [self MR_addSqliteStoreNamed:storeFileName withOptions:options];
+}
+
 - (NSPersistentStore *) MR_addAutoMigratingSqliteStoreAtURL:(NSURL *)storeURL
 {
     NSDictionary *options = [[self class] MR_autoMigrationOptions];
@@ -261,15 +268,22 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
 
 + (NSPersistentStoreCoordinator *) MR_coordinatorWithAutoMigratingSqliteStoreNamed:(NSString *) storeFileName
 {
+    return [self MR_coordinatorWithAutoMigratingSqliteStoreNamed:storeFileName withOptions:nil];
+}
+
++ (NSPersistentStoreCoordinator *) MR_coordinatorWithAutoMigratingSqliteStoreNamed:(NSString *)storeFileName withOptions:(NSDictionary *) options
+{
     NSManagedObjectModel *model = [NSManagedObjectModel MR_defaultManagedObjectModel];
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    
-    [coordinator MR_addAutoMigratingSqliteStoreNamed:storeFileName];
-    
+
+    [coordinator MR_addAutoMigratingSqliteStoreNamed:storeFileName withOptions:options];
+
     //HACK: lame solution to fix automigration error "Migration failed after first pass"
-    if ([[coordinator persistentStores] count] == 0) 
+    if ([[coordinator persistentStores] count] == 0)
     {
-        [coordinator performSelector:@selector(MR_addAutoMigratingSqliteStoreNamed:) withObject:storeFileName afterDelay:0.5];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [coordinator performSelector:@selector(MR_addAutoMigratingSqliteStoreNamed:withOptions:) withObject:storeFileName withObject:options];
+        });
     }
 
     return coordinator;


### PR DESCRIPTION
To allow custom Data Protection level on the Core Data store files, we need to set a custom `NSPersistentStoreFileProtectionKey` on the persistent store. Exposing two API variants to allow us to pass in custom options. 

Refactored `+ MR_coordinatorWithAutoMigratingSqliteStoreNamed:withOptions:` to add the passed in options on top of `+MR_autoMigrationOptions`.
