### PR TITLE
Add AutoCreateDefaultContext Control

### DIFF
--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -44,7 +44,8 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
 + (NSManagedObjectContext *) MR_defaultContext
 {
     @synchronized(self) {
-        if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordDefaultContext) {
+        if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordDefaultContext)
+        {
             [NSPersistentStoreCoordinator MR_defaultStoreCoordinator];
         }
         NSAssert(MagicalRecordDefaultContext != nil, @"Default context is nil! Did you forget to initialize the Core Data Stack?");
@@ -54,7 +55,8 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
 
 + (NSManagedObjectContext *) MR_rootSavingContext;
 {
-    if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordRootSavingContext) {
+    if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordRootSavingContext)
+    {
         [NSPersistentStoreCoordinator MR_defaultStoreCoordinator];
     }
     NSAssert(MagicalRecordRootSavingContext != nil, @"Root saving context is nil! Did you forget to initialize the Core Data Stack?");

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -44,6 +44,9 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
 + (NSManagedObjectContext *) MR_defaultContext
 {
     @synchronized(self) {
+        if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordDefaultContext) {
+            [NSPersistentStoreCoordinator MR_defaultStoreCoordinator];
+        }
         NSAssert(MagicalRecordDefaultContext != nil, @"Default context is nil! Did you forget to initialize the Core Data Stack?");
         return MagicalRecordDefaultContext;
     }
@@ -51,6 +54,9 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
 
 + (NSManagedObjectContext *) MR_rootSavingContext;
 {
+    if ([MagicalRecord shouldAutoCreateDefaultContext]&&!MagicalRecordRootSavingContext) {
+        [NSPersistentStoreCoordinator MR_defaultStoreCoordinator];
+    }
     NSAssert(MagicalRecordRootSavingContext != nil, @"Root saving context is nil! Did you forget to initialize the Core Data Stack?");
     return MagicalRecordRootSavingContext;
 }

--- a/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSPersistentStoreCoordinator+MagicalRecord.m
@@ -10,6 +10,7 @@
 #import "NSManagedObjectModel+MagicalRecord.h"
 #import "MagicalRecord+ErrorHandling.h"
 #import "MagicalRecordLogging.h"
+#import "NSManagedObjectContext+MagicalRecord.h"
 
 
 static NSPersistentStoreCoordinator *defaultCoordinator_ = nil;
@@ -55,6 +56,10 @@ NSString * const kMagicalRecordPSCMismatchCouldNotRecreateStore = @"kMagicalReco
         if ([persistentStores count] && [NSPersistentStore MR_defaultPersistentStore] == nil)
         {
             [NSPersistentStore MR_setDefaultPersistentStore:[persistentStores firstObject]];
+        }
+        if ([MagicalRecord shouldAutoCreateDefaultContext])
+        {
+            [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
         }
     }
 }

--- a/MagicalRecord/Core/MagicalRecord+Options.h
+++ b/MagicalRecord/Core/MagicalRecord+Options.h
@@ -104,6 +104,24 @@ typedef NS_ENUM (NSUInteger, MagicalRecordLoggingLevel)
 + (void) setShouldAutoCreateDefaultPersistentStoreCoordinator:(BOOL)autoCreate;
 
 /**
+ If this is true, the default context will be automatically created if it doesn't exist by calling `[NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:[NSPersistentCoordinator MR_defaultStoreCoordinator]]`.
+ 
+ @return current value of shouldAutoCreateDefaultContext.
+ 
+ @since Available in v2.3.4 and later.
+ */
++ (BOOL) shouldAutoCreateDefaultContext;
+
+/**
+ Setting this to true will make MagicalRecord create the default context(s) automatically if it doesn't exist when called.
+ 
+ @param autoCreate BOOL value that flags whether the default context should be automatically created.
+ 
+ @since Available in v2.3.4 and later.
+ */
++ (void) setShouldAutoCreateDefaultContext:(BOOL)autoCreate;
+
+/**
  If this is true and MagicalRecord encounters a store with a version that does not match that of the model, the store will be removed from the disk.
  This is extremely useful during development where frequent model changes can potentially require a delete and reinstall of the app.
 

--- a/MagicalRecord/Core/MagicalRecord+Options.m
+++ b/MagicalRecord/Core/MagicalRecord+Options.m
@@ -15,6 +15,7 @@ static MagicalRecordLoggingLevel kMagicalRecordLoggingLevel = MagicalRecordLoggi
 #endif
 static BOOL kMagicalRecordShouldAutoCreateManagedObjectModel = NO;
 static BOOL kMagicalRecordShouldAutoCreateDefaultPersistentStoreCoordinator = NO;
+static BOOL kMagicalRecordShouldAutoCreateDefaultContext = NO;
 static BOOL kMagicalRecordShouldDeleteStoreOnModelMismatch = NO;
 
 @implementation MagicalRecord (Options)
@@ -39,6 +40,15 @@ static BOOL kMagicalRecordShouldDeleteStoreOnModelMismatch = NO;
 + (void) setShouldAutoCreateDefaultPersistentStoreCoordinator:(BOOL)autoCreate;
 {
     kMagicalRecordShouldAutoCreateDefaultPersistentStoreCoordinator = autoCreate;
+}
+
++ (BOOL) shouldAutoCreateDefaultContext {
+    return kMagicalRecordShouldAutoCreateDefaultContext;
+}
+
++ (void) setShouldAutoCreateDefaultContext:(BOOL)autoCreate
+{
+    kMagicalRecordShouldAutoCreateDefaultContext = autoCreate;
 }
 
 + (BOOL) shouldDeleteStoreOnModelMismatch;

--- a/MagicalRecord/Core/MagicalRecord+Setup.m
+++ b/MagicalRecord/Core/MagicalRecord+Setup.m
@@ -10,6 +10,7 @@
 #import "NSManagedObject+MagicalRecord.h"
 #import "NSPersistentStoreCoordinator+MagicalRecord.h"
 #import "NSManagedObjectContext+MagicalRecord.h"
+#import "MagicalRecord+Options.h"
 
 @implementation MagicalRecord (Setup)
 
@@ -29,8 +30,11 @@
     
 	NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithSqliteStoreNamed:storeName];
     [NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:coordinator];
-	
-    [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    
+    if (![MagicalRecord shouldAutoCreateDefaultContext])
+    {
+        [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    }
 }
 
 + (void) setupCoreDataStackWithAutoMigratingSqliteStoreNamed:(NSString *)storeName
@@ -40,7 +44,10 @@
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithAutoMigratingSqliteStoreNamed:storeName];
     [NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:coordinator];
     
-    [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    if (![MagicalRecord shouldAutoCreateDefaultContext])
+    {
+        [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    }
 }
 
 + (void) setupCoreDataStackWithStoreAtURL:(NSURL *)storeURL
@@ -50,7 +57,10 @@
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithSqliteStoreAtURL:storeURL];
     [NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:coordinator];
     
-    [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    if (![MagicalRecord shouldAutoCreateDefaultContext])
+    {
+        [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    }
 }
 
 + (void) setupCoreDataStackWithAutoMigratingSqliteStoreAtURL:(NSURL *)storeURL
@@ -60,7 +70,10 @@
     NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithAutoMigratingSqliteStoreAtURL:storeURL];
     [NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:coordinator];
     
-    [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    if (![MagicalRecord shouldAutoCreateDefaultContext])
+    {
+        [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    }
 }
 
 + (void) setupCoreDataStackWithInMemoryStore;
@@ -70,7 +83,10 @@
 	NSPersistentStoreCoordinator *coordinator = [NSPersistentStoreCoordinator MR_coordinatorWithInMemoryStore];
 	[NSPersistentStoreCoordinator MR_setDefaultStoreCoordinator:coordinator];
 	
-    [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    if (![MagicalRecord shouldAutoCreateDefaultContext])
+    {
+        [NSManagedObjectContext MR_initializeDefaultContextWithCoordinator:coordinator];
+    }
 }
 
 @end

--- a/MagicalRecord/Core/MagicalRecordInternal.m
+++ b/MagicalRecord/Core/MagicalRecordInternal.m
@@ -98,6 +98,7 @@ NSString * const kMagicalRecordCleanedUpNotification = @"kMagicalRecordCleanedUp
     {
         [self setShouldAutoCreateManagedObjectModel:YES];
         [self setShouldAutoCreateDefaultPersistentStoreCoordinator:NO];
+        [self setShouldAutoCreateDefaultContext:NO];
 #ifdef DEBUG
         [self setShouldDeleteStoreOnModelMismatch:YES];
 #else

--- a/MagicalRecord/MagicalRecord.h
+++ b/MagicalRecord/MagicalRecord.h
@@ -20,7 +20,6 @@ FOUNDATION_EXPORT const unsigned char MagicalRecordVersionString[];
 
 #import <MagicalRecord/MagicalRecord+Actions.h>
 #import <MagicalRecord/MagicalRecord+ErrorHandling.h>
-#import <MagicalRecord/MagicalRecord+Options.h>
 #import <MagicalRecord/MagicalRecord+Setup.h>
 #import <MagicalRecord/MagicalRecord+iCloud.h>
 


### PR DESCRIPTION
I created this control because I am running Magical Record within a
framework. And the setup called by the main process does not work for
the internal framework methods. This fix seems to be working now.

Also I removed:
-#import <MagicalRecord/MagicalRecord+Options.h>
From the Main header because you call that import at the top of:
MagicalRecordLogging.h
Which is already imported in the header so it was redundant. 