### PR TITLE
Fix crash for custom validation errors

### DIFF
--- a/Library/Categories/Foundation/NSError+MagicalRecordErrorHandling.m
+++ b/Library/Categories/Foundation/NSError+MagicalRecordErrorHandling.m
@@ -55,6 +55,12 @@ NSString *MR_errorSummaryFromErrorCode(NSInteger errorCode)
     for (NSError *error in [self MR_errorCollection])
     {
         NSManagedObject *errorObject = [error MR_validationErrorObject];
+        
+        // custom validation errors may not contain NSValidationObjectErrorKey
+        if(!errorObject) 
+        {
+            continue;
+        }
 
         NSMutableArray *errorList = [collatedObjects objectForKey:[errorObject objectID]];
         if (errorList == nil)


### PR DESCRIPTION
I have a custom validator on NSManagedObject subclass which does not return `NSValidationObjectErrorKey`. This causes crash in magical record. I think MR should skip errors that it cannot extract valuable information from.
