### PR TITLE
Duplicated records using importFromObject with custom classes, even though relatedByAttribute is set correctly

### DIFF
--- a/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/Library/Categories/CoreData/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -279,13 +279,14 @@ NSString *const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"u
     {
         relatedValue = singleRelatedObjectData;
     }
-    else if ([singleRelatedObjectData isKindOfClass:[NSDictionary class]])
-    {
-        relatedValue = [singleRelatedObjectData MR_relatedValueForRelationship:relationshipInfo];
-    }
+//    else if ([singleRelatedObjectData isKindOfClass:[NSDictionary class]])
+//    {
+//        relatedValue = [singleRelatedObjectData MR_relatedValueForRelationship:relationshipInfo];
+//    }
     else
     {
-        relatedValue = singleRelatedObjectData;
+//        relatedValue = singleRelatedObjectData;
+        relatedValue = [singleRelatedObjectData MR_relatedValueForRelationship:relationshipInfo];
     }
 
     if (relatedValue)


### PR DESCRIPTION
I'm using a library that receives a JSON file from a API and creates custom classes from JSON.
I'm using the importFromObject to persist those custom classes (not NSDictionary) in Core Data and I'm having problems with duplicated records being created.
After some debugging I've discovered an issue with MagicalRecord. With the changed in this pull request, the relationship defined in the model is respected and the object is not duplicated.

Please let me know if a sample project is needed.

Regards