### PR TITLE
FIX MR_importFromObject when primaryAttribute type mismatch

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -310,7 +310,10 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
         if (primaryAttribute != nil)
         {
-            id value = [objectData MR_valueForAttribute:primaryAttribute];
+//            id value = [objectData MR_valueForAttribute:primaryAttribute];
+            NSString *lookupKeyPath = [objectData MR_lookupKeyForAttribute:primaryAttribute];
+            id value = [primaryAttribute MR_valueForKeyPath:lookupKeyPath fromObjectData:objectData];
+
             managedObject = [self MR_findFirstByAttribute:[primaryAttribute name] withValue:value inContext:context];
         }
         if (managedObject == nil)


### PR DESCRIPTION
when importing json with "uid" property of type - NSString
to NSManagedObject with primaryAttribute "uid" of type - NSNumber
MR_importFromObject creates duplicate of already existing object