### PR TITLE
Fixed a warning when linking from an app extension

### DIFF
--- a/MagicalRecord.xcodeproj/project.pbxproj
+++ b/MagicalRecord.xcodeproj/project.pbxproj
@@ -2155,6 +2155,7 @@
 		905D072B1A63DE190076B54E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -2197,6 +2198,7 @@
 		905D072C1A63DE190076B54E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
When an app extension was using the framework built by `carthage` there
was a warning "linking against a dylib which is not safe for use in
application extensions".

This build setting makes linker much happier and mitigates the warning.