### PR TITLE
Remove dead links & add Swift tutorial reference

### DIFF
--- a/Docs/Other-Resources.md
+++ b/Docs/Other-Resources.md
@@ -3,7 +3,4 @@
 The following articles highlight how to install and use aspects of MagicalRecord:
 
 * [How to make Programming with Core Data Pleasant](http://yannickloriot.com/2012/03/magicalrecord-how-to-make-programming-with-core-data-pleasant/)
-* [Using Core Data with MagicalRecord](http://ablfx.com/blog/2012/03/using-coredata-magicalrecord/)
-* [Super Happy Easy Fetching in Core Data](http://www.cimgf.com/2011/03/13/super-happy-easy-fetching-in-core-data/)
-* [Core Data and Threads, without the Headache](http://www.cimgf.com/2011/05/04/core-data-and-threads-without-the-headache/)
-* [Unit Testing with Core Data](http://www.cimgf.com/2012/05/15/unit-testing-with-core-data/)
+* [Using MagicalRecord with Swift](https://www.raywenderlich.com/106856/getting-started-magicalrecord)


### PR DESCRIPTION
Several of the links in `Other-Resources.md` were no longer working. Also added a raywenderlich reference to using MagicalRecord with Swift.