### PR TITLE
removing expecta to allow potential watchOS and tvOS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/expecta"]
-	path = Carthage/Checkouts/expecta
-	url = https://github.com/specta/expecta.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,0 @@
-github "specta/expecta" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "specta/expecta" "v1.0.3"

--- a/MagicalRecord.xcodeproj/project.pbxproj
+++ b/MagicalRecord.xcodeproj/project.pbxproj
@@ -203,10 +203,6 @@
 		902CE12D18F61A2F0024F47C /* MagicalRecord+ActionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902CE12B18F61A2F0024F47C /* MagicalRecord+ActionsTests.m */; };
 		902CE13918F61E410024F47C /* NSManagedObjectContext+MagicalSavesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902CE13818F61E410024F47C /* NSManagedObjectContext+MagicalSavesTests.m */; };
 		902CE13A18F61E410024F47C /* NSManagedObjectContext+MagicalSavesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 902CE13818F61E410024F47C /* NSManagedObjectContext+MagicalSavesTests.m */; };
-		903125A11B10384A000E8841 /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 903125941B103812000E8841 /* Expecta.framework */; };
-		903125A21B103860000E8841 /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 903125921B103812000E8841 /* Expecta.framework */; };
-		903125A31B103881000E8841 /* libExpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9031259A1B103812000E8841 /* libExpecta.a */; };
-		903125A41B103886000E8841 /* libExpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9031259C1B103812000E8841 /* libExpecta.a */; };
 		90542E121863F20900916224 /* MagicalDataImportTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = C7CF978E174982AD008D9D13 /* MagicalDataImportTestCase.m */; };
 		90542E131863F20900916224 /* MagicalDataImportTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = C7CF978E174982AD008D9D13 /* MagicalDataImportTestCase.m */; };
 		90542E141863F20C00916224 /* ImportSingleEntityWithNoRelationshipsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C7CF978B174982AD008D9D13 /* ImportSingleEntityWithNoRelationshipsTests.m */; };
@@ -337,8 +333,6 @@
 		905D07C51A63DF130076B54E /* MagicalRecord+iCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = C7DD72CA150F832A00216827 /* MagicalRecord+iCloud.m */; };
 		905D07C61A63DF130076B54E /* MagicalRecord+Options.m in Sources */ = {isa = PBXBuildFile; fileRef = C7DD72CC150F832A00216827 /* MagicalRecord+Options.m */; };
 		905D07C71A63DF130076B54E /* MagicalRecord+Setup.m in Sources */ = {isa = PBXBuildFile; fileRef = C7DD72CE150F832A00216827 /* MagicalRecord+Setup.m */; };
-		9088CFC61B1043F500E51758 /* Expecta.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 903125921B103812000E8841 /* Expecta.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9088CFC71B10440800E51758 /* Expecta.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 903125941B103812000E8841 /* Expecta.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9099490A17C2F3D400BC2B5C /* TestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9099490817C2F3D400BC2B5C /* TestModel.xcdatamodeld */; };
 		9099490B17C2F3D400BC2B5C /* TestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9099490817C2F3D400BC2B5C /* TestModel.xcdatamodeld */; };
 		9099493917C2F42100BC2B5C /* _AbstractRelatedEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 9099490E17C2F42100BC2B5C /* _AbstractRelatedEntity.m */; };
@@ -551,7 +545,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9088CFC71B10440800E51758 /* Expecta.framework in Copy Frameworks */,
 				9004F57A1A94D7D300A61312 /* MagicalRecord.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -563,7 +556,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9088CFC61B1043F500E51758 /* Expecta.framework in Copy Frameworks */,
 				9004F57D1A94D7F100A61312 /* MagicalRecord.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -696,7 +688,6 @@
 		9099493617C2F42100BC2B5C /* SingleEntityWithNoRelationships.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SingleEntityWithNoRelationships.m; sourceTree = "<group>"; };
 		9099493717C2F42100BC2B5C /* SingleRelatedEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleRelatedEntity.h; sourceTree = "<group>"; };
 		9099493817C2F42100BC2B5C /* SingleRelatedEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SingleRelatedEntity.m; sourceTree = "<group>"; };
-		90A0DE031C50D59300CF5A5A /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = SOURCE_ROOT; };
 		90A0DE051C50D59300CF5A5A /* MagicalRecord.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MagicalRecord.podspec; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		90AA771718F79A3300D49377 /* NSManagedObject+MagicalRecordTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+MagicalRecordTests.m"; sourceTree = "<group>"; };
 		90AA772318F79CCC00D49377 /* EntityWithoutEntityNameMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntityWithoutEntityNameMethod.h; sourceTree = "<group>"; };
@@ -800,7 +791,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9004F5231A94CBF300A61312 /* MagicalRecord.framework in Frameworks */,
-				903125A11B10384A000E8841 /* Expecta.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -808,7 +798,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				903125A21B103860000E8841 /* Expecta.framework in Frameworks */,
 				9004F5681A94CC0E00A61312 /* MagicalRecord.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -845,7 +834,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				903125A41B103886000E8841 /* libExpecta.a in Frameworks */,
 				9004F4DF1A94C76E00A61312 /* libMagicalRecord.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -854,7 +842,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				903125A31B103881000E8841 /* libExpecta.a in Frameworks */,
 				9004F4DE1A94C76A00A61312 /* libMagicalRecord.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -889,7 +876,6 @@
 		90425374187102DC0066DA41 /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				90A0DE031C50D59300CF5A5A /* Cartfile.private */,
 				90A0DE051C50D59300CF5A5A /* MagicalRecord.podspec */,
 				905D07C91A63DFED0076B54E /* Info.plist */,
 			);

--- a/Tests/Core/MagicalRecord+ActionsTests.m
+++ b/Tests/Core/MagicalRecord+ActionsTests.m
@@ -21,13 +21,13 @@
     [MagicalRecord saveWithBlockAndWait:^(NSManagedObjectContext *localContext) {
         NSManagedObject *inserted = [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
         [localContext obtainPermanentIDsForObjects:@[inserted] error:nil];
         objectId = [inserted objectID];
     }];
 
-    expect(objectId).toNot.beNil();
+    XCTAssertNotNil(objectId);
 
     XCTestExpectation *rootSavingExpectation = [self expectationWithDescription:@"Root Saving Context Fetch Object"];
     NSManagedObjectContext *rootSavingContext = [NSManagedObjectContext MR_rootSavingContext];
@@ -36,9 +36,9 @@
         NSError *fetchError;
         NSManagedObject *fetchedObject = [rootSavingContext existingObjectWithID:objectId error:&fetchError];
 
-        expect(fetchedObject).toNot.beNil();
-        expect(fetchError).to.beNil();
-        expect([fetchedObject hasChanges]).to.beFalsy();
+        XCTAssertNotNil(fetchedObject);
+        XCTAssertNil(fetchError);
+        XCTAssertFalse(fetchedObject.hasChanges);
 
         [rootSavingExpectation fulfill];
     }];
@@ -53,13 +53,13 @@
     [MagicalRecord saveWithBlockAndWait:^(NSManagedObjectContext *localContext) {
         NSManagedObject *inserted = [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
         [localContext obtainPermanentIDsForObjects:@[inserted] error:nil];
         objectId = [inserted objectID];
     }];
 
-    expect(objectId).toNot.beNil();
+    XCTAssertNotNil(objectId);
 
     XCTestExpectation *rootSavingExpectation = [self expectationWithDescription:@"Root Saving Context Fetch Object"];
     NSManagedObjectContext *rootSavingContext = [NSManagedObjectContext MR_rootSavingContext];
@@ -68,9 +68,9 @@
         NSError *fetchError;
         NSManagedObject *fetchedObject = [rootSavingContext existingObjectWithID:objectId error:&fetchError];
 
-        expect(fetchedObject).toNot.beNil();
-        expect(fetchError).to.beNil();
-        expect([fetchedObject hasChanges]).to.beFalsy();
+        XCTAssertNotNil(fetchedObject);
+        XCTAssertNil(fetchError);
+        XCTAssertFalse(fetchedObject.hasChanges);
 
         [rootSavingExpectation fulfill];
     }];
@@ -90,7 +90,7 @@
 
         [inserted setValue:@YES forKey:kTestAttributeKey];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
         [localContext obtainPermanentIDsForObjects:@[inserted] error:nil];
         objectId = [inserted objectID];
@@ -101,7 +101,7 @@
 
     [rootSavingContext performBlock:^{
         fetchedObject = [rootSavingContext objectWithID:objectId];
-        expect([fetchedObject valueForKey:kTestAttributeKey]).to.beTruthy();
+        XCTAssertTrue([fetchedObject valueForKey:kTestAttributeKey]);
 
         [rootSavingExpectation fulfill];
     }];
@@ -120,7 +120,7 @@
         fetchedObject = [rootSavingContext objectWithID:objectId];
 
         // Async since the merge to the main thread context after persistence
-        expect([fetchedObject valueForKey:kTestAttributeKey]).to.beFalsy();
+        XCTAssertEqualObjects([fetchedObject valueForKey:kTestAttributeKey], @NO);
 
         [rootSavingExpectation fulfill];
     }];
@@ -141,19 +141,19 @@
     [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) {
         NSManagedObject *inserted = [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
-        expect([localContext obtainPermanentIDsForObjects:@[inserted] error:nil]).to.beTruthy();
+        XCTAssertTrue([localContext obtainPermanentIDsForObjects:@[inserted] error:nil]);
         objectId = [inserted objectID];
 
-        expect(objectId).toNot.beNil();
-        expect(objectId.isTemporaryID).to.beFalsy();
+        XCTAssertNotNil(objectId);
+        XCTAssertFalse(objectId.isTemporaryID);
     } completion:^(BOOL contextDidSave, NSError *error) {
         saveSuccessState = contextDidSave;
         saveError = error;
 
-        expect(saveSuccessState).to.beTruthy();
-        expect(saveError).to.beNil();
+        XCTAssertTrue(saveSuccessState);
+        XCTAssertNil(saveError);
 
         NSManagedObjectContext *rootSavingContext = [NSManagedObjectContext MR_rootSavingContext];
 
@@ -161,9 +161,9 @@
             NSError *existingObjectError;
             NSManagedObject *existingObject = [rootSavingContext existingObjectWithID:objectId error:&existingObjectError];
 
-            expect(existingObject).toNot.beNil();
-            expect([existingObject hasChanges]).to.beFalsy();
-            expect(existingObjectError).to.beNil();
+            XCTAssertNotNil(existingObject);
+            XCTAssertFalse(existingObject.hasChanges);
+            XCTAssertNil(existingObjectError);
 
             [expectation fulfill];
         }];
@@ -179,7 +179,7 @@
     [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) {
         [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
     } completion:^(BOOL contextDidSave, NSError *error) {
-        expect([NSThread isMainThread]).to.beTruthy();
+        XCTAssertTrue(NSThread.isMainThread);
 
         [expectation fulfill];
     }];
@@ -196,19 +196,19 @@
     [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) {
         NSManagedObject *inserted = [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
         [localContext obtainPermanentIDsForObjects:@[inserted] error:nil];
         objectId = [inserted objectID];
     } completion:^(BOOL contextDidSave, NSError *error) {
-        expect(contextDidSave).to.beTruthy();
+        XCTAssertTrue(contextDidSave);
 
         NSManagedObjectContext *rootSavingContext = [NSManagedObjectContext MR_rootSavingContext];
 
         [rootSavingContext performBlock:^{
             NSManagedObject *fetchedObject = [rootSavingContext objectWithID:objectId];
-            expect(fetchedObject).toNot.beNil();
-            expect([fetchedObject hasChanges]).to.beFalsy();
+            XCTAssertNotNil(fetchedObject);
+            XCTAssertFalse(fetchedObject.hasChanges);
 
             [contextSavedExpectation fulfill];
         }];
@@ -229,7 +229,7 @@
 
         [inserted setValue:@YES forKey:kTestAttributeKey];
 
-        expect([inserted hasChanges]).to.beTruthy();
+        XCTAssertTrue(inserted.hasChanges);
 
         [localContext obtainPermanentIDsForObjects:@[inserted] error:nil];
         objectId = [inserted objectID];
@@ -239,7 +239,7 @@
 
     [rootSavingContext performBlockAndWait:^{
         fetchedObject = [[NSManagedObjectContext MR_rootSavingContext] objectWithID:objectId];
-        expect([fetchedObject valueForKey:kTestAttributeKey]).to.beTruthy();
+        XCTAssertTrue([fetchedObject valueForKey:kTestAttributeKey]);
     }];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for managed object context"];
@@ -251,8 +251,8 @@
     } completion:^(BOOL contextDidSave, NSError *error) {
         [rootSavingContext performBlock:^{
             fetchedObject = [rootSavingContext objectWithID:objectId];
-            expect(fetchedObject).toNot.beNil();
-            expect([fetchedObject valueForKey:kTestAttributeKey]).to.beFalsy();
+            XCTAssertNotNil(fetchedObject);
+            XCTAssertEqualObjects([fetchedObject valueForKey:kTestAttributeKey], @NO);
 
             [expectation fulfill];
         }];

--- a/Tests/Core/MagicalRecord+ShorthandTests.m
+++ b/Tests/Core/MagicalRecord+ShorthandTests.m
@@ -21,15 +21,15 @@
 
 - (void)testLongFormMethodsAreStillAvailableWhenShorthandIsEnabled
 {
-    expect([NSManagedObjectContext class]).to.respondTo(@selector(MR_rootSavingContext));
-    expect([NSManagedObjectContext MR_rootSavingContext]).to.respondTo(@selector(MR_saveWithBlock:));
+    XCTAssertTrue([[NSManagedObjectContext class] respondsToSelector:@selector(MR_rootSavingContext)]);
+    XCTAssertTrue([[NSManagedObjectContext MR_rootSavingContext] respondsToSelector:@selector(MR_saveWithBlock:)]);
 }
 
 - (void)testShorthandMethodsAreAvailableWhenEnabled
 {
-    expect([NSManagedObjectContext class]).to.respondTo(@selector(rootSavingContext));
-    expect([NSManagedObjectContext rootSavingContext]).toNot.beNil();
-    expect([NSManagedObjectContext rootSavingContext]).to.respondTo(@selector(saveWithBlock:));
+    XCTAssertTrue([[NSManagedObjectContext class] respondsToSelector:@selector(rootSavingContext)]);
+    XCTAssertNotNil([NSManagedObjectContext rootSavingContext]);
+    XCTAssertTrue([[NSManagedObjectContext rootSavingContext] respondsToSelector:@selector(saveWithBlock:)]);
 }
 
 @end

--- a/Tests/Core/MagicalRecord+StackTests.m
+++ b/Tests/Core/MagicalRecord+StackTests.m
@@ -5,7 +5,6 @@
 
 #import <XCTest/XCTest.h>
 #import <CoreData/CoreData.h>
-#import <Expecta/Expecta.h>
 
 #import <MagicalRecord/MagicalRecord.h>
 #import "MagicalRecordTestHelpers.h"

--- a/Tests/Core/MagicalRecordTestBase.h
+++ b/Tests/Core/MagicalRecordTestBase.h
@@ -5,7 +5,6 @@
 
 #import <XCTest/XCTest.h>
 #import <CoreData/CoreData.h>
-#import <Expecta/Expecta.h>
 #import <MagicalRecord/MagicalRecord.h>
 
 @interface MagicalRecordTestBase : XCTestCase

--- a/Tests/Core/NSManagedObject+MagicalRecordTests.m
+++ b/Tests/Core/NSManagedObject+MagicalRecordTests.m
@@ -17,15 +17,15 @@
 
 - (void)testThatInternalEntityNameReturnsClassNameWhenEntityNameMethodIsNotImplemented
 {
-    expect([EntityWithoutEntityNameMethod MR_entityName]).toNot.beNil();
-    expect([EntityWithoutEntityNameMethod MR_entityName]).to.equal(NSStringFromClass([EntityWithoutEntityNameMethod class]));
+    XCTAssertNotNil([EntityWithoutEntityNameMethod MR_entityName]);
+    XCTAssertEqualObjects([EntityWithoutEntityNameMethod MR_entityName], NSStringFromClass([EntityWithoutEntityNameMethod class]));
 }
 
 - (void)testThatInternalEntityNameReturnsProvidedNameWhenEntityNameMethodIsImplemented
 {
-    expect([EntityWithoutEntityNameMethod MR_entityName]).toNot.beNil();
-    expect([DifferentClassNameMapping MR_entityName]).toNot.equal(NSStringFromClass([DifferentClassNameMapping class]));
-    expect([DifferentClassNameMapping MR_entityName]).to.equal([DifferentClassNameMapping entityName]);
+    XCTAssertNotNil([EntityWithoutEntityNameMethod MR_entityName]);
+    XCTAssertNotEqualObjects([DifferentClassNameMapping MR_entityName], NSStringFromClass([DifferentClassNameMapping class]));
+    XCTAssertEqualObjects([DifferentClassNameMapping MR_entityName], [DifferentClassNameMapping entityName]);
 }
 
 @end

--- a/Tests/Core/NSManagedObjectContext+ChainSaveTests.m
+++ b/Tests/Core/NSManagedObjectContext+ChainSaveTests.m
@@ -26,29 +26,29 @@
     [defaultContext MR_saveWithBlock:^(NSManagedObjectContext *localContext) {
         SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:localContext];
 
-        expect([insertedObject hasChanges]).to.beTruthy();
+        XCTAssertTrue(insertedObject.hasChanges);
 
         NSError *obtainIDsError;
         BOOL obtainIDsResult = [localContext obtainPermanentIDsForObjects:@[ insertedObject ] error:&obtainIDsError];
 
-        expect(obtainIDsResult).to.beTruthy();
-        expect(obtainIDsError).to.beNil();
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
         childObjectID = [insertedObject objectID];
 
-        expect(childObjectID).toNot.beNil();
-        expect([childObjectID isTemporaryID]).to.beFalsy();
+        XCTAssertNotNil(childObjectID);
+        XCTAssertFalse(childObjectID.isTemporaryID);
 
     } completion:^(BOOL success, NSError *error) {
 
         //test parent and root saving context
         SingleEntityWithNoRelationships *parentObject = (SingleEntityWithNoRelationships *)[defaultContext objectWithID:childObjectID];
 
-        expect(parentObject).toNot.beNil();
+        XCTAssertNotNil(parentObject);
 
         SingleEntityWithNoRelationships *rootObject = (SingleEntityWithNoRelationships *)[[NSManagedObjectContext MR_rootSavingContext] objectWithID:childObjectID];
 
-        expect(rootObject).toNot.beNil();
+        XCTAssertNotNil(rootObject);
 
     }];
 }

--- a/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
+++ b/Tests/Core/NSManagedObjectContext+MagicalSavesTests.m
@@ -25,18 +25,18 @@
     [childContext performBlockAndWait:^{
         insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
 
-        expect([insertedObject hasChanges]).to.beTruthy();
+        XCTAssertTrue(insertedObject.hasChanges);
 
         NSError *obtainIDsError;
         BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[insertedObject] error:&obtainIDsError];
 
-        expect(obtainIDsResult).to.beTruthy();
-        expect(obtainIDsError).to.beNil();
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
         insertedObjectID = [insertedObject objectID];
 
-        expect(insertedObjectID).toNot.beNil();
-        expect([insertedObjectID isTemporaryID]).to.beFalsy();
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
         
         [childContext MR_saveOnlySelfAndWait];
 
@@ -53,15 +53,15 @@
 
         // Saving a child context moves the saved changes up to the parent, but does
         //  not save them, leaving the parent context with changes
-        expect(parentContextFetchedObject).toNot.beNil();
-        expect([parentContextFetchedObject hasChanges]).to.beTruthy();
+        XCTAssertNotNil(parentContextFetchedObject);
+        XCTAssertTrue(parentContextFetchedObject.hasChanges);
 
         [childContext performBlockAndWait:^{
             NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
 
             // The child context should not have changes after the save
-            expect(childContextFetchedObject).toNot.beNil();
-            expect([childContextFetchedObject hasChanges]).to.beFalsy();
+            XCTAssertNotNil(childContextFetchedObject);
+            XCTAssertFalse(childContextFetchedObject.hasChanges);
 
             [childContextSavedExpectation fulfill];
         }];
@@ -84,26 +84,26 @@
     [childContext performBlock:^{
         SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
 
-        expect([insertedObject hasChanges]).to.beTruthy();
+        XCTAssertTrue(insertedObject.hasChanges);
 
         NSError *obtainIDsError;
         BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[insertedObject] error:&obtainIDsError];
 
-        expect(obtainIDsResult).to.beTruthy();
-        expect(obtainIDsError).to.beNil();
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
         NSManagedObjectID *insertedObjectID = [insertedObject objectID];
 
-        expect(insertedObjectID).toNot.beNil();
-        expect([insertedObjectID isTemporaryID]).to.beFalsy();
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
 
         [childContext MR_saveOnlySelfWithCompletion:^(BOOL contextDidSave, NSError *error) {
-            expect(contextDidSave).to.beTruthy();
-            expect(error).to.beNil();
+            XCTAssertTrue(contextDidSave);
+            XCTAssertNil(error);
 
             [childContext performBlock:^{
                 // The child context should not have changes after the save
-                expect([childContext hasChanges]).to.beFalsy();
+                XCTAssertFalse(childContext.hasChanges);
 
                 [childContextSaveExpectation fulfill];
             }];
@@ -113,8 +113,8 @@
 
                 // Saving a child context moves the saved changes up to the parent, but does
                 //  not save them, leaving the parent context with changes
-                expect(parentContextFetchedObject).toNot.beNil();
-                expect([parentContextFetchedObject hasChanges]).to.beTruthy();
+                XCTAssertNotNil(parentContextFetchedObject);
+                XCTAssertTrue(parentContextFetchedObject.hasChanges);
 
                 [parentContextExpectation fulfill];
             }];
@@ -131,12 +131,12 @@
     NSManagedObjectContext *defaultContext = [NSManagedObjectContext MR_defaultContext];
     NSManagedObject *inserted = [SingleEntityWithNoRelationships MR_createEntityInContext:defaultContext];
 
-    expect([inserted hasChanges]).to.beTruthy();
+    XCTAssertTrue(inserted.hasChanges);
 
     XCTestExpectation *contextSavedExpectation = [self expectationWithDescription:@"Context Did Save"];
 
     [defaultContext MR_saveOnlySelfWithCompletion:^(BOOL contextDidSave, NSError *error) {
-        expect([NSThread isMainThread]).to.beTruthy();
+        XCTAssertTrue(NSThread.isMainThread);
 
         [contextSavedExpectation fulfill];
     }];
@@ -155,18 +155,18 @@
     [childContext performBlockAndWait:^{
         insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
 
-        expect([insertedObject hasChanges]).to.beTruthy();
+        XCTAssertTrue(insertedObject.hasChanges);
 
         NSError *obtainIDsError;
         BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[insertedObject] error:&obtainIDsError];
 
-        expect(obtainIDsResult).to.beTruthy();
-        expect(obtainIDsError).to.beNil();
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
         insertedObjectID = [insertedObject objectID];
 
-        expect(insertedObjectID).toNot.beNil();
-        expect([insertedObjectID isTemporaryID]).to.beFalsy();
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
     }];
 
     [childContext MR_saveToPersistentStoreAndWait];
@@ -177,17 +177,17 @@
 
         // Saving to the persistent store should save to all parent contexts,
         //  leaving no changes
-        expect(fetchExistingObjectFromParentContextError).to.beNil();
-        expect(parentContextFetchedObject).toNot.beNil();
-        expect([parentContextFetchedObject hasChanges]).to.beFalsy();
+        XCTAssertNil(fetchExistingObjectFromParentContextError);
+        XCTAssertNotNil(parentContextFetchedObject);
+        XCTAssertFalse(parentContextFetchedObject.hasChanges);
     }];
 
     [childContext performBlockAndWait:^{
         NSManagedObject *childContextFetchedObject = [childContext objectRegisteredForID:insertedObjectID];
 
         // The child context should not have changes after the save
-        expect(childContextFetchedObject).toNot.beNil();
-        expect([childContextFetchedObject hasChanges]).to.beFalsy();
+        XCTAssertNotNil(childContextFetchedObject);
+        XCTAssertFalse(childContextFetchedObject.hasChanges);
     }];
 }
 
@@ -202,22 +202,22 @@
     [childContext performBlock:^{
         SingleEntityWithNoRelationships *insertedObject = [SingleEntityWithNoRelationships MR_createEntityInContext:childContext];
 
-        expect([insertedObject hasChanges]).to.beTruthy();
+        XCTAssertTrue(insertedObject.hasChanges);
 
         NSError *obtainIDsError;
         BOOL obtainIDsResult = [childContext obtainPermanentIDsForObjects:@[insertedObject] error:&obtainIDsError];
 
-        expect(obtainIDsResult).to.beTruthy();
-        expect(obtainIDsError).to.beNil();
+        XCTAssertTrue(obtainIDsResult);
+        XCTAssertNil(obtainIDsError);
 
         NSManagedObjectID *insertedObjectID = [insertedObject objectID];
 
-        expect(insertedObjectID).toNot.beNil();
-        expect([insertedObjectID isTemporaryID]).to.beFalsy();
+        XCTAssertNotNil(insertedObjectID);
+        XCTAssertFalse(insertedObjectID.isTemporaryID);
 
         [childContext MR_saveToPersistentStoreWithCompletion:^(BOOL contextDidSave, NSError *error) {
-            expect(contextDidSave).to.beTruthy();
-            expect(error).to.beNil();
+            XCTAssertTrue(contextDidSave);
+            XCTAssertNil(error);
 
             [parentContext performBlockAndWait:^{
                 NSError *fetchExistingObjectFromParentContextError;
@@ -225,14 +225,14 @@
 
                 // Saving to the persistent store should save to all parent contexts,
                 //  leaving no changes
-                expect(fetchExistingObjectFromParentContextError).to.beNil();
-                expect(parentContextFetchedObject).toNot.beNil();
-                expect([parentContextFetchedObject hasChanges]).to.beFalsy();
+                XCTAssertNil(fetchExistingObjectFromParentContextError);
+                XCTAssertNotNil(parentContextFetchedObject);
+                XCTAssertFalse(parentContextFetchedObject.hasChanges);
             }];
 
             [childContext performBlockAndWait:^{
                 // The child context should not have changes after the save
-                expect([childContext hasChanges]).to.beFalsy();
+                XCTAssertFalse(childContext.hasChanges);
             }];
 
             [childContextSavedExpectation fulfill];
@@ -251,11 +251,11 @@
     [defaultContext performBlockAndWait:^{
         SingleEntityWithNoRelationships *entity = [SingleEntityWithNoRelationships MR_createEntityInContext:defaultContext];
 
-        expect([[entity objectID] isTemporaryID]).to.beTruthy();
+        XCTAssertTrue([entity objectID].isTemporaryID);
 
         [defaultContext MR_saveOnlySelfAndWait];
 
-        expect([[entity objectID] isTemporaryID]).to.beFalsy();
+        XCTAssertFalse([entity objectID].isTemporaryID);
     }];
 }
 


### PR DESCRIPTION
Removing Expecta like it was done for branch 3.0.
There is no feature from Expecta that we use that isn't available natively as XCTAssert.
This change will also prepare support for tvOS and watchOS.