### PR TITLE
Use only numbers from git tags when creating CFBundleShortVersionString

### DIFF
--- a/Support/Scripts/set_version_information.sh
+++ b/Support/Scripts/set_version_information.sh
@@ -3,6 +3,7 @@
 git=$(sh /etc/profile; which git)
 number_of_commits=$("$git" rev-list HEAD --count)
 git_release_version=$("$git" describe --tags --always --abbrev=0)
+clear_release_version=$(echo $git_release_version | grep -o -E '[0-9]+')
 
 target_plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
 dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"
@@ -10,6 +11,6 @@ dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"
 for plist in "$target_plist" "$dsym_plist"; do
   if [ -f "$plist" ]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $number_of_commits" "$plist"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${git_release_version#*v}" "$plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${clear_release_version#*v}" "$plist"
   fi
 done

--- a/Support/Scripts/set_version_information.sh
+++ b/Support/Scripts/set_version_information.sh
@@ -3,7 +3,7 @@
 git=$(sh /etc/profile; which git)
 number_of_commits=$("$git" rev-list HEAD --count)
 git_release_version=$("$git" describe --tags --always --abbrev=0)
-clear_release_version=$(echo $git_release_version | grep -o -E '[0-9]+')
+clear_release_version=${git_release_version//[!0-9]/}
 
 target_plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
 dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"


### PR DESCRIPTION
In the company I work with we use MagicalRecord and Carthage as a dependency manager. Due to this problem, we had to fork the repository with the modification described because we used tags in git in the following format: `beta/202010111458` and when compiling MagicalRecord, this text was like CFBundleShortVersionString and resulted in the issue `"This bundle is The value for key CFBundleShortVersionString 'beta/202010111458' in the Info.plist file must be a period-separated list of at most three non-negative integers."`. 

So this modification in the `set_version_information.sh` script solves the problem and I think it might be interesting for other projects that use lib, as described in the issue #1259.

Anyway, this PR is one of my contributions for [Hacktoberfest 2020](https://hacktoberfest.digitalocean.com/), so even if it's not merged, I would love it if a maintainer could add the `hacktoberfest-accepted` tag in PR if it is an interesting contribution. 😄 